### PR TITLE
Auto pause and resume

### DIFF
--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -39,6 +39,9 @@ class Machine(object):
         # The list of chips with Ethernet connections
         self._ethernet_connected_chips = list()
 
+        # The dictonary of chips via their nearest ethernet connected chip
+        self._chips_by_local_ethernet = dict()
+
         # The dictionary of spinnaker links by "id" (int)
         self._spinnaker_links = dict()
 
@@ -70,6 +73,24 @@ class Machine(object):
 
         if chip.ip_address is not None:
             self._ethernet_connected_chips.append(chip)
+
+        chip_id = (chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+        if chip_id not in self._chips_by_local_ethernet:
+            self._chips_by_local_ethernet = list()
+        self._chips_by_local_ethernet[chip_id].append(chip)
+
+    def get_chips_via_local_ethernet(self, local_ethernet_x, local_ethernet_y):
+        """
+        returns a list of chips which have the nearest ethenet chip of x and y
+        :param local_ethernet_x: the ethernet chip x coord
+        :param local_ethernet_y: the ethernet chip y coord
+        :return: list of chips
+        """
+        chip_id = (local_ethernet_x, local_ethernet_y)
+        if chip_id not in self._chips_by_local_ethernet:
+            return []
+        else:
+            return self._chips_by_local_ethernet[chip_id]
 
     def add_chips(self, chips):
         """ Add some chips to the machine

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -8,10 +8,6 @@ from spinn_machine.exceptions import SpinnMachineAlreadyExistsException
 # general imports
 from collections import OrderedDict
 
-# current opinions is that the ethernet connected chip can handle 10 udp packets
-# per millisecond
-MAX_BANDWIDTH_PER_ETHERNET_CONNECTED_CHIP = 10 * 256
-
 
 class Machine(object):
     """ A Representation of a Machine with a number of Chips.  Machine is also\
@@ -21,6 +17,10 @@ class Machine(object):
             * y is the y-coordinate of a chip
             * chip is the chip with the given x, y coordinates
     """
+
+    # current opinions is that the ethernet connected chip can handle 10
+    # udp packets per millisecond
+    MAX_BANDWIDTH_PER_ETHERNET_CONNECTED_CHIP = 10 * 256
 
     def __init__(self, chips):
         """

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -8,6 +8,10 @@ from spinn_machine.exceptions import SpinnMachineAlreadyExistsException
 # general imports
 from collections import OrderedDict
 
+# current opinions is that the ethernet connected chip can handle 10 udp packets
+# per millisecond
+MAX_BANDWIDTH_PER_ETHERNET_CONNECTED_CHIP = 10 * 256
+
 
 class Machine(object):
     """ A Representation of a Machine with a number of Chips.  Machine is also\

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -1,6 +1,3 @@
-"""
-Machine
-"""
 
 # spinn_machine imports
 from spinn_machine.exceptions import SpinnMachineAlreadyExistsException
@@ -18,8 +15,8 @@ class Machine(object):
             * chip is the chip with the given x, y coordinates
     """
 
-    # current opinions is that the ethernet connected chip can handle 10
-    # udp packets per millisecond
+    # current opinions is that the Ethernet connected chip can handle 10
+    # UDP packets per millisecond
     MAX_BANDWIDTH_PER_ETHERNET_CONNECTED_CHIP = 10 * 256
 
     def __init__(self, chips):
@@ -39,7 +36,7 @@ class Machine(object):
         # The list of chips with Ethernet connections
         self._ethernet_connected_chips = list()
 
-        # The dictonary of chips via their nearest ethernet connected chip
+        # The dictionary of chips via their nearest Ethernet connected chip
         self._chips_by_local_ethernet = dict()
 
         # The dictionary of spinnaker links by "id" (int)
@@ -81,9 +78,9 @@ class Machine(object):
 
     def get_chips_via_local_ethernet(self, local_ethernet_x, local_ethernet_y):
         """
-        returns a list of chips which have the nearest ethenet chip of x and y
-        :param local_ethernet_x: the ethernet chip x coord
-        :param local_ethernet_y: the ethernet chip y coord
+        returns a list of chips which have the nearest Ethernet chip of x and y
+        :param local_ethernet_x: the Ethernet chip x coord
+        :param local_ethernet_y: the Ethernet chip y coord
         :return: list of chips
         """
         chip_id = (local_ethernet_x, local_ethernet_y)

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -76,7 +76,7 @@ class Machine(object):
 
         chip_id = (chip.nearest_ethernet_x, chip.nearest_ethernet_y)
         if chip_id not in self._chips_by_local_ethernet:
-            self._chips_by_local_ethernet = list()
+            self._chips_by_local_ethernet[chip_id] = list()
         self._chips_by_local_ethernet[chip_id].append(chip)
 
     def get_chips_via_local_ethernet(self, local_ethernet_x, local_ethernet_y):


### PR DESCRIPTION
Allows you to run for an arbitrary number of timesteps, even when that means that recorded data will exceed the space on the machine. Even supports runtimes greater than originally allocated. 