### PR TITLE
Fix vm chip layout

### DIFF
--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -240,8 +240,8 @@ class VirtualMachine(Machine):
                 (x, y) not in down_chips
             })
         else:
-            self._configured_chips = OrderedSet((x, y) for x in range(height)
-                                                for y in range(width) if
+            self._configured_chips = OrderedSet((x, y) for x in range(width)
+                                                for y in range(height) if
                                                 (x, y) not in down_chips)
 
         # Assign "ip addresses" to the Ethernet chips

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -285,11 +285,10 @@ class TestVirtualMachine(unittest.TestCase):
         vm = virtual_machine.VirtualMachine(width=48, height=24,
                                             with_wrap_arounds=True)
         for eth_chip in vm._ethernet_connected_chips:
-            if not vm.get_chip_at(eth_chip.x, eth_chip.y):
-                self.assertTrue(False,
-                                "Eth chip location x={}, y={} not in "
-                                "_configured_chips"
-                                .format(eth_chip.x, eth_chip.y))
+            self.assertTrue(vm.get_chip_at(eth_chip.x, eth_chip.y),
+                            "Eth chip location x={}, y={} not in "
+                            "_configured_chips"
+                            .format(eth_chip.x, eth_chip.y))
 
     @unittest.skip("skipping test_initlize_neighbour_links_for_other_boards")
     def test_initlize_neighbour_links_for_other_boards(self):

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -281,6 +281,15 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(vm.maximum_user_cores_on_chip,
                          n_chips - 2)
 
+    def test_ethernet_chips_exist(self):
+        vm = virtual_machine.VirtualMachine(width=24,height=48,
+                                            with_wrap_arounds=True)
+        for eth_chip in vm._ethernet_connected_chips:
+            if not vm.get_chip_at(eth_chip.x,eth_chip.y):
+                self.assertTrue(False,
+                    "Eth chip location x={}, y={} not in _configured_chips"
+                    .format(eth_chip.x, eth_chip.y))
+
     @unittest.skip("skipping test_initlize_neighbour_links_for_other_boards")
     def test_initlize_neighbour_links_for_other_boards(self):
         self.assertEqual(True, False, "Test not implemented yet")
@@ -292,6 +301,11 @@ class TestVirtualMachine(unittest.TestCase):
     @unittest.skip("skipping test_calculate_links")
     def test_calculate_links(self):
         self.assertEqual(True, False, "Test not implemented yet")
+
+
+
+
+
 
 
 if __name__ == '__main__':

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -282,13 +282,14 @@ class TestVirtualMachine(unittest.TestCase):
                          n_chips - 2)
 
     def test_ethernet_chips_exist(self):
-        vm = virtual_machine.VirtualMachine(width=24,height=48,
+        vm = virtual_machine.VirtualMachine(width=48, height=24,
                                             with_wrap_arounds=True)
         for eth_chip in vm._ethernet_connected_chips:
-            if not vm.get_chip_at(eth_chip.x,eth_chip.y):
+            if not vm.get_chip_at(eth_chip.x, eth_chip.y):
                 self.assertTrue(False,
-                    "Eth chip location x={}, y={} not in _configured_chips"
-                    .format(eth_chip.x, eth_chip.y))
+                                "Eth chip location x={}, y={} not in "
+                                "_configured_chips"
+                                .format(eth_chip.x, eth_chip.y))
 
     @unittest.skip("skipping test_initlize_neighbour_links_for_other_boards")
     def test_initlize_neighbour_links_for_other_boards(self):
@@ -301,6 +302,7 @@ class TestVirtualMachine(unittest.TestCase):
     @unittest.skip("skipping test_calculate_links")
     def test_calculate_links(self):
         self.assertEqual(True, False, "Test not implemented yet")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -302,11 +302,5 @@ class TestVirtualMachine(unittest.TestCase):
     def test_calculate_links(self):
         self.assertEqual(True, False, "Test not implemented yet")
 
-
-
-
-
-
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Found the issue causing the VM to appear to be the incorrect size: the VirtualMachine._configured_chips OrderedSet was being configured with the width and height swapped.

The Ethernet chips were being created correctly (according to the machine dimensions obtained from spalloc), and although they were added to the Machine._chips dictionary, it was never checked that these locations tallied with those in _configured_chips. Therefore, when the resource_tracker tried to grab these chips, it got nothing back.

There may be more we can do in terms of protecting against errors in both the VirtualMachine and Machine classes, and also the ResourceTracker, but for now a unit test has been included to prevent this specific error reoccurring.