### PR TITLE
Chip power monitor

### DIFF
--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -626,11 +626,22 @@ class Machine(object):
 
     @property
     def total_available_user_cores(self):
+        """ provides total number of cores on the machine which are not \
+            monitor cores
+        
+        :return: total
+        :rtype: int
+        """
         return len([
             processor for chip in self.chips for processor in chip.processors
             if not processor.is_monitor])
 
     @property
     def total_cores(self):
+        """ provides total number of cores on the machine, includes monitors
+        
+        :return: total
+        :rtype: int
+        """
         return len([
             processor for chip in self.chips for processor in chip.processors])

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -618,3 +618,14 @@ class Machine(object):
         """ The maximum number of user cores on any chip
         """
         return self._maximum_user_cores_on_chip
+
+    @property
+    def total_available_user_cores(self):
+        return len([
+            processor for chip in self.chips for processor in chip.processors
+            if not processor.is_monitor])
+
+    @property
+    def total_cores(self):
+        return len([
+            processor for chip in self.chips for processor in chip.processors])

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -628,7 +628,7 @@ class Machine(object):
     def total_available_user_cores(self):
         """ provides total number of cores on the machine which are not \
             monitor cores
-        
+
         :return: total
         :rtype: int
         """
@@ -639,7 +639,7 @@ class Machine(object):
     @property
     def total_cores(self):
         """ provides total number of cores on the machine, includes monitors
-        
+
         :return: total
         :rtype: int
         """


### PR DESCRIPTION
creates a summary energy report. 

- [x] creates report
- [x] looks like it could be correct
- [ ] verify against real power measurements.

tied to 
PAC   https://github.com/SpiNNakerManchester/PACMAN/pull/98
FEC https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/155
spynnaker https://github.com/SpiNNakerManchester/sPyNNaker/pull/341
gfe https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/51