### PR TITLE
source_y=y, not source_y=x ... nice bug...

### DIFF
--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -317,27 +317,27 @@ class VirtualMachine(Machine):
             return self._chips[x, y].router.is_link(link)
         if link == 0:
             return self._creatable_link(
-                link_from=link, source_x=x, source_y=x,
+                link_from=link, source_x=x, source_y=y,
                 destination_x=x + 1, destination_y=y)
         if link == 1:
             return self._creatable_link(
-                link_from=link, source_x=x, source_y=x,
+                link_from=link, source_x=x, source_y=y,
                 destination_x=x + 1, destination_y=y + 1)
         if link == 2:
             return self._creatable_link(
-                link_from=link, source_x=x, source_y=x,
+                link_from=link, source_x=x, source_y=y,
                 destination_x=x, destination_y=y + 1)
         if link == 3:
             return self._creatable_link(
-                link_from=link, source_x=x, source_y=x,
+                link_from=link, source_x=x, source_y=y,
                 destination_x=x - 1, destination_y=y)
         if link == 4:
             return self._creatable_link(
-                link_from=link, source_x=x, source_y=x,
+                link_from=link, source_x=x, source_y=y,
                 destination_x=x - 1, destination_y=y - 1)
         if link == 5:
             return self._creatable_link(
-                link_from=link, source_x=x, source_y=x,
+                link_from=link, source_x=x, source_y=y,
                 destination_x=x, destination_y=y - 1)
         return False  # Illegal link value
 


### PR DESCRIPTION
Came across this when trying to get virtual machine integration tests to work...