### PR TITLE
Speed up data extractor

### DIFF
--- a/spinn_machine/fixed_route_entry.py
+++ b/spinn_machine/fixed_route_entry.py
@@ -48,3 +48,6 @@ class FixedRouteEntry(object):
         """
         return self._link_ids
 
+
+    def __repr__(self):
+        return "{}:{}".format(self._link_ids, self._processor_ids)

--- a/spinn_machine/processor.py
+++ b/spinn_machine/processor.py
@@ -95,10 +95,6 @@ class Processor(object):
         """ Creates a clone of this processor but changing it to a system\
             processor.
 
-        The current implementation does not distinguish between\
-        monitor processors and reinjector ones but could do so at a later\
-        stage.
-
         :return: A new Processor with the same properties INCLUDING id\
             except now set as a System processor
         :rtype: spinn_machine.Processor


### PR DESCRIPTION
gives us a 5.4 times speed up on simple synfire chain. likely to give more for larger sims. 

depends upon the following prs:

- [ ] https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/229
- [ ] https://github.com/SpiNNakerManchester/PACMAN/pull/131
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker7/pull/41
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker/pull/429
- [ ] https://github.com/SpiNNakerManchester/sPyNNaker8/pull/84
- [ ] https://github.com/SpiNNakerManchester/SpiNNMan/pull/100
- [ ] https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/71



Note that this work is not finished, but is stable. Future work will come which will increase this even further