### PR TITLE
Simple issues found by pylint

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -24,6 +24,7 @@ class Chip(object):
         "_n_user_processors"
     )
 
+    # pylint: disable=too-many-arguments
     def __init__(self, x, y, processors, router, sdram, nearest_ethernet_x,
                  nearest_ethernet_y, ip_address=None, virtual=False,
                  tag_ids=IPTAG_IDS):

--- a/spinn_machine/core_subsets.py
+++ b/spinn_machine/core_subsets.py
@@ -6,7 +6,7 @@ class CoreSubsets(object):
     """ Represents a group of CoreSubsets, with a maximum of one per chip
     """
 
-    __slots__ = ("_core_subsets")
+    __slots__ = ("_core_subsets", )
 
     def __init__(self, core_subsets=None):
         """
@@ -113,10 +113,7 @@ class CoreSubsets(object):
     def __len__(self):
         """ The total number of processors that are in these core subsets
         """
-        counter = 0
-        for xy in self._core_subsets:
-            counter += len(self._core_subsets[xy])
-        return counter
+        return sum(len(subset) for subset in self._core_subsets)
 
     def __contains__(self, x_y_tuple):
         """ True if the given coordinates are in the set
@@ -126,11 +123,8 @@ class CoreSubsets(object):
             processor_id coordinates
         """
         if len(x_y_tuple) == 2:
-            (x, y) = x_y_tuple
-            return self.is_chip(x, y)
-        else:
-            (x, y, p) = x_y_tuple
-            return self.is_core(x, y, p)
+            return self.is_chip(*x_y_tuple)
+        return self.is_core(*x_y_tuple)
 
     def __get_item__(self, x_y_tuple):
         """ The core subset for the given x, y tuple
@@ -144,5 +138,5 @@ class CoreSubsets(object):
         """
         output = ""
         for xy in self._core_subsets:
-            output += "{}".format(xy)
+            output += str(xy)
         return output

--- a/spinn_machine/link.py
+++ b/spinn_machine/link.py
@@ -13,6 +13,7 @@ class Link(object):
         "_multicast_default_to", "_source_link_id", "_source_x", "_source_y"
     )
 
+    # pylint: disable=too-many-arguments
     def __init__(self, source_x, source_y, source_link_id, destination_x,
                  destination_y, multicast_default_from, multicast_default_to):
         """

--- a/spinn_machine/link_data_objects/fpga_link_data.py
+++ b/spinn_machine/link_data_objects/fpga_link_data.py
@@ -10,6 +10,7 @@ class FPGALinkData(AbstractLinkData):
         "_fpga_id"
     )
 
+    # pylint: disable=too-many-arguments
     def __init__(self, fpga_link_id, fpga_id, connected_chip_x,
                  connected_chip_y, connected_link, board_address):
         AbstractLinkData.__init__(

--- a/spinn_machine/link_data_objects/spinnaker_link_data.py
+++ b/spinn_machine/link_data_objects/spinnaker_link_data.py
@@ -5,10 +5,9 @@ class SpinnakerLinkData(AbstractLinkData):
     """ Data object for spinnaker links
     """
 
-    __slots__ = (
-        "_spinnaker_link_id"
-    )
+    __slots__ = ("_spinnaker_link_id", )
 
+    # pylint: disable=too-many-arguments
     def __init__(self, spinnaker_link_id, connected_chip_x, connected_chip_y,
                  connected_link, board_address):
         AbstractLinkData.__init__(

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -505,14 +505,14 @@ class Machine(object):
                         self._add_fpga_link(fpga_id, fpga_link, x, y, 4, ip)
                         fpga_link += 1
 
+    # pylint: disable=too-many-arguments
     def _add_fpga_link(self, fpga_id, fpga_link, x, y, link, board_address):
-        if self.is_chip_at(x, y):
-            if not self.is_link_at(x, y, link):
-                self._fpga_links[board_address, fpga_id, fpga_link] = \
-                    FPGALinkData(
-                        fpga_link_id=fpga_link, fpga_id=fpga_id,
-                        connected_chip_x=x, connected_chip_y=y,
-                        connected_link=link, board_address=board_address)
+        if self.is_chip_at(x, y) and not self.is_link_at(x, y, link):
+            self._fpga_links[board_address, fpga_id, fpga_link] = \
+                FPGALinkData(
+                    fpga_link_id=fpga_link, fpga_id=fpga_id,
+                    connected_chip_x=x, connected_chip_y=y,
+                    connected_link=link, board_address=board_address)
 
     def __str__(self):
         return "[Machine: max_x={}, max_y={}, n_chips={}]".format(

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -12,6 +12,7 @@ class MulticastRoutingEntry(object):
         "_link_ids"
     )
 
+    # pylint: disable=too-many-arguments
     def __init__(self, routing_entry_key, mask, processor_ids, link_ids,
                  defaultable):
         """

--- a/spinn_machine/sdram.py
+++ b/spinn_machine/sdram.py
@@ -7,7 +7,7 @@ class SDRAM(object):
 
     DEFAULT_SDRAM_BYTES = 117 * 1024 * 1024
 
-    __slots__ = "_size"
+    __slots__ = ("_size", )
 
     def __init__(self, size=DEFAULT_SDRAM_BYTES):
         """

--- a/spinn_machine/spinnaker_triad_geometry.py
+++ b/spinn_machine/spinnaker_triad_geometry.py
@@ -124,14 +124,15 @@ class SpiNNakerTriadGeometry(object):
             key=lambda tupl: tupl[2])
         return (x1, y1)
 
+    # pylint: disable=too-many-arguments
     def get_ethernet_chip_coordinates(
             self, x, y, width, height, root_x=0, root_y=0):
         """ Get the coordinates of a chip's local Ethernet connected chip\
             according to this triad geometry object
 
         .. warning::
-            :py:meth:`.local_eth_coord` will always produce the
-            coordinates of the Ethernet-connected SpiNNaker chip on the same
+            :py:meth:`.local_eth_coord` will always produce the\
+            coordinates of the Ethernet-connected SpiNNaker chip on the same\
             SpiNN-5 board as the supplied chip.  This chip may not actually\
             be working.
 

--- a/spinn_machine/tags/iptag.py
+++ b/spinn_machine/tags/iptag.py
@@ -16,6 +16,7 @@ class IPTag(AbstractTag):
         "_destination_y"
     ]
 
+    # pylint: disable=too-many-arguments
     def __init__(
             self, board_address, destination_x, destination_y, tag, ip_address,
             port=None, strip_sdp=False, traffic_identifier="DEFAULT"):
@@ -93,16 +94,13 @@ class IPTag(AbstractTag):
     def __eq__(self, other):
         if not isinstance(other, IPTag):
             return False
-        else:
-            if (self._ip_address == other._ip_address and
-                    self._strip_sdp == other._strip_sdp and
-                    self._board_address == other.board_address and
-                    self._port == other.port and
-                    self._tag == other.tag and
-                    self._traffic_identifier == other.traffic_identifier):
-                return True
-            else:
-                return False
+        # pylint: disable=protected-access
+        return (self._ip_address == other._ip_address and
+                self._strip_sdp == other._strip_sdp and
+                self._board_address == other.board_address and
+                self._port == other.port and
+                self._tag == other.tag and
+                self._traffic_identifier == other.traffic_identifier)
 
     def __hash__(self):
         return hash((self._ip_address, self._strip_sdp, self._board_address,

--- a/spinn_machine/tags/reverse_iptag.py
+++ b/spinn_machine/tags/reverse_iptag.py
@@ -22,6 +22,7 @@ class ReverseIPTag(AbstractTag):
         "_sdp_port"
     ]
 
+    # pylint: disable=too-many-arguments
     def __init__(self, board_address, tag, port, destination_x, destination_y,
                  destination_p, sdp_port=1):
         """

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -39,6 +39,7 @@ class VirtualMachine(Machine):
         (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)
     }
 
+    # pylint: disable=too-many-arguments
     def __init__(
             self, width=None, height=None, with_wrap_arounds=False,
             version=None, n_cpus_per_chip=18, with_monitors=True,
@@ -114,7 +115,7 @@ class VirtualMachine(Machine):
                 raise SpinnMachineInvalidParameterException(
                     "version and with_wrap_arounds",
                     "{} and True".format(version),
-                    "A version {} board does not have wrap arounds; set "
+                    "A version {} board does not have wrap-arounds; set "
                     "version to None or with_wrap_arounds to None"
                     .format(version))
             if ((width is not None and width != 8) or
@@ -148,12 +149,11 @@ class VirtualMachine(Machine):
                     "version, width, height, with_wrap_arounds",
                     "{}, {}, {}, {}".format(
                         version, width, height, with_wrap_arounds),
-                    "A generic machine with wrap arounds None"
+                    "A generic machine with wrap-arounds None"
                     " must be either have a width and height "
                     " which are both either 2 or 8 or a width"
                     " and height that are divisible by 12"
-                    " or a width - 4 and height - 4 that are divisible by 12"
-                    .format(version))
+                    " or a width - 4 and height - 4 that are divisible by 12")
 
         if (version is None and (with_wrap_arounds is True) and
                 not ((width == 8 and height == 8) or
@@ -163,9 +163,9 @@ class VirtualMachine(Machine):
                 "version, width, height, with_wrap_arounds",
                 "{}, {}, {}, {}".format(
                     version, width, height, with_wrap_arounds),
-                "A generic machine with wrap arounds must be either have a"
+                "A generic machine with wrap-arounds must be either have a"
                 " width and height which are both either 2 or 8 or a width"
-                " and height that are divisible by 12".format(version))
+                " and height that are divisible by 12")
 
         if (version is None and (with_wrap_arounds is False) and
                 not ((width == 8 and height == 8) or
@@ -175,17 +175,17 @@ class VirtualMachine(Machine):
                 "version, width, height, with_wrap_arounds",
                 "{}, {}, {}, {}".format(
                     version, width, height, with_wrap_arounds),
-                "A generic machine without wrap arounds must be either have a"
+                "A generic machine without wrap-arounds must be either have a"
                 " width and height which are both either 2 or 8 or a width - 4"
-                " and height - 4 that are divisible by 12".format(version))
+                " and height - 4 that are divisible by 12")
 
         if with_wrap_arounds is None:
-            logger.debug("width = {}, height = {} and auto wrap arounds"
-                         .format(width, height))
+            logger.debug("width = %d, height = %d and auto wrap-arounds",
+                         width, height)
         else:
             self._with_wrap_arounds = with_wrap_arounds
-            logger.debug("width = {}, height = {} and wrap arounds {}"
-                         .format(width, height, self._with_wrap_arounds))
+            logger.debug("width = %d, height = %d and wrap-arounds %s",
+                         width, height, self._with_wrap_arounds)
 
         # Set up the maximum chip x and y
         self._max_chip_x = width - 1
@@ -197,10 +197,7 @@ class VirtualMachine(Machine):
         # Store the details
         self._n_cpus_per_chip = n_cpus_per_chip
         self._sdram_per_chip = sdram_per_chip
-        if with_monitors:
-            self._with_monitors = 1
-        else:
-            self._with_monitors = 0
+        self._with_monitors = int(bool(with_monitors))
         self._default_processors = dict()
 
         # Store the down items
@@ -243,19 +240,16 @@ class VirtualMachine(Machine):
                 (x + eth_x, y + eth_y) for x in range(8) for y in range(8)
                 for eth_x, eth_y in ethernet_chips
                 if (x, y) not in Machine.BOARD_48_CHIP_GAPS and
-                (x, y) not in down_chips
-            })
+                (x, y) not in down_chips})
         else:
             self._configured_chips = OrderedSet((x, y) for x in range(width)
                                                 for y in range(height) if
                                                 (x, y) not in down_chips)
 
         # Assign "ip addresses" to the Ethernet chips
-        for i in range(len(ethernet_chips)):
+        for i, (x, y) in enumerate(ethernet_chips):
             (a, b) = divmod(i + 1, 128)
-            ip_address = "127.0.{}.{}".format(a, b)
-            (x, y) = ethernet_chips[i]
-            new_chip = self._create_chip(x, y, ip_address)
+            new_chip = self._create_chip(x, y, "127.0.{}.{}".format(a, b))
             Machine.add_chip(self, new_chip)
 
         self.add_spinnaker_links(version)
@@ -280,7 +274,7 @@ class VirtualMachine(Machine):
     @property
     def chips(self):
         for (x, y) in self.chip_coordinates:
-            if not (x, y) in self._chips:
+            if (x, y) not in self._chips:
                 Machine.add_chip(self, self._create_chip(x, y))
             yield self._chips[(x, y)]
 
@@ -293,7 +287,7 @@ class VirtualMachine(Machine):
 
     def __iter__(self):
         for (x, y) in self.chip_coordinates:
-            if not (x, y) in self._chips:
+            if (x, y) not in self._chips:
                 Machine.add_chip(self, self._create_chip(x, y))
             yield (x, y), self._chips[(x, y)]
 
@@ -457,9 +451,9 @@ class VirtualMachine(Machine):
 
         # Check only against chips that can be created
         # Chips directly added will have the links directly added as well
-        if not (source_x, source_y) in self._configured_chips:
+        if (source_x, source_y) not in self._configured_chips:
             return False
-        if not (destination_x, destination_y) in self._configured_chips:
+        if (destination_x, destination_y) not in self._configured_chips:
             return False
         if (source_x, source_y, link_from) in self._down_links:
             return False


### PR DESCRIPTION
Remaining issues: some methods are too complicated and should be refactored for comprehensibility.

Relevant output from `propspector`:

```
spinn_machine/machine.py
  Line: 361
    pylint: too-many-statements / Too many statements (83/60) (col 4)
    mccabe: MC0001 / Machine.add_fpga_links is too complex (21)

spinn_machine/virtual_machine.py
  Line: 43
    pylint: too-many-locals / Too many local variables (23/15) (col 4)
    pylint: too-many-statements / Too many statements (86/60) (col 4)
    mccabe: MC0001 / VirtualMachine.__init__ is too complex (33)
```