### PR TITLE
Fix for calling this function across multiple boards

### DIFF
--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -585,7 +585,7 @@ class Machine(object):
                 x = eth_x + chip_x
                 y = eth_y + chip_y
                 if (self.is_chip_at(x, y) and
-                        (x, y) not in Machine.BOARD_48_CHIP_GAPS):
+                        (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
                     yield x, y
 
     def reserve_system_processors(self):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -582,10 +582,15 @@ class Machine(object):
         eth_y = chip.nearest_ethernet_y
         for chip_x in range(0, 8):
             for chip_y in range(0, 8):
-                x = eth_x + chip_x
-                y = eth_y + chip_y
+                if (self.has_wrap_arounds):
+                    x = (eth_x + chip_x) % (self._max_chip_x + 1)
+                    y = (eth_y + chip_y) % (self._max_chip_y + 1)
+                else:
+                    x = eth_x + chip_x
+                    y = eth_y + chip_y
+
                 if (self.is_chip_at(x, y) and
-                        (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
+                    (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
                     yield x, y
 
     def reserve_system_processors(self):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -659,5 +659,6 @@ class Machine(object):
         :return: True if wrap around links exist, false otherwise
         :rtype: bool
         """
-        return (self.max_chip_x+1 == 2 and self.max_chip_y+1 == 2) or \
-            (self.max_chip_x+1 % 12 == 0 and self.max_chip_y+1 % 12 == 0)
+        return ((self.max_chip_x + 1 == 2 and self.max_chip_y+1 == 2) or
+                ((self.max_chip_x + 1) % 12 == 0 and
+                 (self.max_chip_y + 1) % 12 == 0))

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -590,8 +590,8 @@ class Machine(object):
                     y = eth_y + chip_y
 
                 if (self.is_chip_at(x, y) and
-                    (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
-                        yield x, y
+                        (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
+                            yield x, y
 
     def reserve_system_processors(self):
         """ Sets one of the none monitor system processors as a system\

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -580,8 +580,12 @@ class Machine(object):
         """
         eth_x = chip.nearest_ethernet_x
         eth_y = chip.nearest_ethernet_y
-        for chip_x in range(0, 8):
-            for chip_y in range(0, 8):
+        if (self._max_chip_x == 1):
+            max_coords = 2
+        else:
+            max_coords = 8
+        for chip_x in range(0, max_coords):
+            for chip_y in range(0, max_coords):
                 if (self.has_wrap_arounds):
                     x = (eth_x + chip_x) % (self._max_chip_x + 1)
                     y = (eth_y + chip_y) % (self._max_chip_y + 1)

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -591,7 +591,7 @@ class Machine(object):
 
                 if (self.is_chip_at(x, y) and
                     (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
-                    yield x, y
+                        yield x, y
 
     def reserve_system_processors(self):
         """ Sets one of the none monitor system processors as a system\

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -259,5 +259,6 @@ class SpinnMachineTestCase(unittest.TestCase):
             self.assertEquals(len(chips), 25)
             self.assertEquals(len(chips_in_machine), 24)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -249,6 +249,15 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertEquals(new_machine.maximum_user_cores_on_chip,
                           len(processors) - 2)
 
+    def test_machine_get_chips_on_board(self):
+        chips = self._create_chips()
+        new_machine = Machine(chips, 0, 0)
+        for eth_chip in new_machine._ethernet_connected_chips:
+            chips_in_machine = list(new_machine.get_chips_on_board(eth_chip))
+            # _create_chips made a 5*5 grid of 25 chips,
+            # but (0,4) is not on a standard 48-node board
+            self.assertEquals(len(chips), 25)
+            self.assertEquals(len(chips_in_machine), 24)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -301,14 +301,14 @@ class TestVirtualMachine(unittest.TestCase):
         count2436 = 0
         for eth_chip in vm._ethernet_connected_chips:
             list_of_chips = list(vm.get_chips_on_board(eth_chip))
-            self.assertEqual(len(list_of_chips),48)
-            if (0,0) in list_of_chips:
+            self.assertEqual(len(list_of_chips), 48)
+            if (0, 0) in list_of_chips:
                 count00 += 1
-            if (5,0) in list_of_chips:
+            if (5, 0) in list_of_chips:
                 count50 += 1
-            if (0,4) in list_of_chips:
+            if (0, 4) in list_of_chips:
                 count04 += 1
-            if (24,36) in list_of_chips:
+            if (24, 36) in list_of_chips:
                 count2436 += 1
 
         # (0,0), (5,0), (0,4) are all on this virtual machine
@@ -318,6 +318,7 @@ class TestVirtualMachine(unittest.TestCase):
 
         # (24,36) is not on this virtual machine
         self.assertEqual(count2436, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -292,6 +292,32 @@ class TestVirtualMachine(unittest.TestCase):
         vm = VirtualMachine(2, 2)
         self.assertNotEqual(vm.boot_chip, None)
 
+    def test_get_chips_on_boards(self):
+        vm = VirtualMachine(width=24, height=36, with_wrap_arounds=True)
+        # check each chip appears only once on the entire board
+        count00 = 0
+        count50 = 0
+        count04 = 0
+        count2436 = 0
+        for eth_chip in vm._ethernet_connected_chips:
+            list_of_chips = list(vm.get_chips_on_board(eth_chip))
+            self.assertEqual(len(list_of_chips),48)
+            if (0,0) in list_of_chips:
+                count00 += 1
+            if (5,0) in list_of_chips:
+                count50 += 1
+            if (0,4) in list_of_chips:
+                count04 += 1
+            if (24,36) in list_of_chips:
+                count2436 += 1
+
+        # (0,0), (5,0), (0,4) are all on this virtual machine
+        self.assertEqual(count00, 1)
+        self.assertEqual(count50, 1)
+        self.assertEqual(count04, 1)
+
+        # (24,36) is not on this virtual machine
+        self.assertEqual(count2436, 0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This was causing me problems when running MCMC over more than 1 board via spalloc.

There should probably be a unit or integration test to check this works properly as well; happy to write it but will have to be next week now...