### PR TITLE
Disallow Single Board Wraps

### DIFF
--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -156,15 +156,14 @@ class VirtualMachine(Machine):
                     " or a width - 4 and height - 4 that are divisible by 12")
 
         if (version is None and (with_wrap_arounds is True) and
-                not ((width == 8 and height == 8) or
-                     (width == 2 and height == 2) or
+                not ((width == 2 and height == 2) or
                      (width % 12 == 0 and height % 12 == 0))):
             raise SpinnMachineInvalidParameterException(
                 "version, width, height, with_wrap_arounds",
                 "{}, {}, {}, {}".format(
                     version, width, height, with_wrap_arounds),
                 "A generic machine with wrap-arounds must be either have a"
-                " width and height which are both either 2 or 8 or a width"
+                " width and height which are both 2 or a width"
                 " and height that are divisible by 12")
 
         if (version is None and (with_wrap_arounds is False) and

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -94,6 +94,24 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(vm.max_chip_y, 7)
         self.assertEqual(48, vm.n_chips)
         self.assertEqual(1, len(vm.ethernet_connected_chips))
+        self.assertTrue(vm.is_chip_at(4, 4))
+        self.assertFalse(vm.is_chip_at(0, 4))
+        count = 0
+        for _chip in vm.chips:
+            for _link in _chip.router.links:
+                count += 1
+        self.assertEqual(240, count)
+
+    def test_8_by_8(self):
+        vm = VirtualMachine(
+            width=8, height=8, version=None, with_wrap_arounds=False)
+        self.assertEqual(vm.max_chip_x, 7)
+        self.assertEqual(vm.max_chip_y, 7)
+        self.assertEqual(48, vm.n_chips)
+        self.assertEqual(1, len(vm.ethernet_connected_chips))
+        self.assertTrue(vm.is_chip_at(4, 4))
+        self.assertFalse(vm.is_chip_at(0, 4))
+        self.assertFalse((0, 4) in list(vm.chip_coordinates))
         count = 0
         for _chip in vm.chips:
             for _link in _chip.router.links:


### PR DESCRIPTION
If an 8x8 machine is specified with wrap_arounds = True, a 64-chip machine is built.  This is disallowed by these changes, as such a machine cannot exist in reality.