### PR TITLE
Delete unused classes

### DIFF
--- a/spinn_machine/utilities/ordered_set.py
+++ b/spinn_machine/utilities/ordered_set.py
@@ -1,7 +1,0 @@
-from spinn_utilities.ordered_set import OrderedSet
-import logging
-
-logger = logging.getLogger(__name__)
-logger.warning("Deprecation Warning: OrderedSet has moved to SpiNNUtils.")
-
-__all__ = ["OrderedSet"]

--- a/spinn_machine/utilities/progress_bar.py
+++ b/spinn_machine/utilities/progress_bar.py
@@ -1,7 +1,0 @@
-from spinn_utilities.progress_bar import ProgressBar
-import logging
-
-logger = logging.getLogger(__name__)
-logger.warning("Deprecation Warning: ProgressBar has moved to SpiNNUtils.")
-
-__all__ = ["ProgressBar"]


### PR DESCRIPTION
These classes are not used any more anywhere within our codebase (because they've been moved to SpiNNUtilites). We have no need to keep these stubs around.