### PR TITLE
Documentation improvements

### DIFF
--- a/spinn_machine/__init__.py
+++ b/spinn_machine/__init__.py
@@ -1,57 +1,58 @@
-"""A python abstraction of a SpiNNaker Machine.  The main functionality is
+"""A python abstraction of a SpiNNaker Machine.  The main functionality is\
 provided by :py:class:`spinn_machine.Machine`.
 
 Functional Requirements
 =======================
 
-    * Create a machine which represents the current state of a machine, in
-      terms of the available chips, cores on the chips, SDRAM available,
+    * Create a machine which represents the current state of a machine, in\
+      terms of the available chips, cores on the chips, SDRAM available,\
       routable links between chips and available routing entries.
 
     * Create a machine which represents an abstract ideal machine.
 
         * There can only be one chip in the machine with given x, y coordinates
 
-        * There can only be one processor in each chip with a given processor
-          id
+        * There can only be one processor in each chip with a given processor\
+          ID
 
-        * There can only be one link in the router of each chip with a given id
+        * There can only be one link in the router of each chip with a given ID
 
     * Add a chip to a given machine to represent an external device.
 
-        * A chip with the same x, y coordinates must not already exist in the
+        * A chip with the same x, y coordinates must not already exist in the\
           machine
 
-    * Add a link to a router of a given chip to represent a connection to an
+    * Add a link to a router of a given chip to represent a connection to an\
       external device.
 
         * A link with the given id must not already exist in the chip
 
-    * Create a representation of a multicast routing entry to be shared between
-      modules that deal with routing entries.
+    * Create a representation of a multicast routing entry to be shared\
+      between modules that deal with routing entries.
 
 Use Cases
 =========
 
-    * :py:class:`~spinn_machine.Machine` is returned as a
-      representation of the current state of a machine.
+    * :py:class:`~spinn_machine.Machine` is returned as a representation of\
+      the current state of a machine.
 
-    * :py:class:`~spinn_machine.Machine` is used as an outline of a
-      machine on which a simulation will be run e.g. for placement of
+    * :py:class:`~spinn_machine.VirtualMachine` is used as an outline of a\
+      machine on which a simulation will be run, e.g., for placement of\
       executables and/or finding routes between placed executables.
 
-    * :py:class:`~spinn_machine.Machine` is extended to add a virtual
-      :py:class:`~spinn_machine.Chip` on the machine representing an
-      external peripheral connected to the machine directly via a link from a
-      chip, so that routes can be directed to and from the external peripheral
+    * :py:class:`~spinn_machine.Machine` is extended to add a virtual\
+      :py:class:`~spinn_machine.Chip` on the machine representing an\
+      external peripheral connected to the machine directly via a link from a\
+      chip, so that routes can be directed to and from the external\
+      peripheral.
 
-    * :py:class:`~spinn_machine.MulticastRoutingEntry`
-      is returned in a list of entries, which indicate the current set of
-      routing entries within a multicast routing table on a chip on the
+    * :py:class:`~spinn_machine.MulticastRoutingEntry`\
+      is returned in a list of entries, which indicate the current set of\
+      routing entries within a multicast routing table on a chip on the\
       machine.
 
-    * :py:class:`~spinn_machine.MulticastRoutingEntry`
-      is sent in a list of routing entries to set up routing on a chip on the
+    * :py:class:`~spinn_machine.MulticastRoutingEntry`\
+      is sent in a list of routing entries to set up routing on a chip on the\
       machine.
 """
 

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -5,13 +5,12 @@ from spinn_utilities.ordered_set import OrderedSet
 
 
 class Chip(object):
-
-    """ Represents a chip with a number of cores, an amount of SDRAM shared
-        between the cores, and a router.\
-        The chip is iterable over the processors providing\
+    """ Represents a SpiNNaker chip with a number of cores, an amount of\
+        SDRAM shared between the cores, and a router.\
+        The chip is iterable over the processors, yielding\
         (processor_id, processor) where:
 
-            * processor_id is the id of a processor
+            * processor_id is the ID of a processor
             * processor is the processor with processor_id
     """
 
@@ -29,7 +28,6 @@ class Chip(object):
                  nearest_ethernet_y, ip_address=None, virtual=False,
                  tag_ids=IPTAG_IDS):
         """
-
         :param x: the x-coordinate of the chip's position in the\
             two-dimensional grid of chips
         :type x: int
@@ -37,22 +35,21 @@ class Chip(object):
             two-dimensional grid of chips
         :type y: int
         :param processors: an iterable of processor objects
-        :type processors: iterable of\
-            :py:class:`spinn_machine.Processor`
+        :type processors: iterable(:py:class:`~spinn_machine.Processor`)
         :param router: a router for the chip
-        :type router: :py:class:`spinn_machine.Router`
+        :type router: :py:class:`~spinn_machine.Router`
         :param sdram: an SDRAM for the chip
-        :type sdram: :py:class:`spinn_machine.SDRAM`
+        :type sdram: :py:class:`~spinn_machine.SDRAM`
         :param ip_address: \
             the IP address of the chip or None if no Ethernet attached
         :type ip_address: str
         :param virtual: boolean which defines if this chip is a virtual one
         :type virtual: bool
-        :param tag_ids: Id to identify the chip for SDP
-        :type tag_ids: iterable of int
-        :param nearest_ethernet_x: the nearest Ethernet x coord
+        :param tag_ids: ID to identify the chip for SDP
+        :type tag_ids: iterable(int)
+        :param nearest_ethernet_x: the nearest Ethernet x coordinate
         :type nearest_ethernet_x: int or None
-        :param nearest_ethernet_y: the nearest Ethernet y coord
+        :param nearest_ethernet_y: the nearest Ethernet y coordinate
         :type nearest_ethernet_y: int or None
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
             If processors contains any two processors with the same\
@@ -79,26 +76,26 @@ class Chip(object):
         self._nearest_ethernet_y = nearest_ethernet_y
 
     def is_processor_with_id(self, processor_id):
-        """ Determines if a processor with the given id exists in the chip.\
+        """ Determines if a processor with the given ID exists in the chip.\
             Also implemented as __contains__(processor_id)
 
-        :param processor_id: the processor id to check for
+        :param processor_id: the processor ID to check for
         :type processor_id: int
-        :return: True or False based on the existence of the processor
+        :return: Whether the processor with the given ID exists
         :rtype: bool
         :raise None: does not raise any known exceptions
         """
         return processor_id in self._p
 
     def get_processor_with_id(self, processor_id):
-        """ Return the processor with the specified id or None if the\
+        """ Return the processor with the specified ID or None if the\
             processor does not exist.
 
-        :param processor_id: the id of the processor to return
+        :param processor_id: the ID of the processor to return
         :type processor_id: int
         :return: \
-            the processor with the specified id, or None if no such processor
-        :rtype: :py:class:`spinn_machine.Processor`
+            the processor with the specified ID, or None if no such processor
+        :rtype: :py:class:`~spinn_machine.Processor`
         :raise None: does not raise any known exceptions
         """
         if processor_id in self._p:
@@ -130,7 +127,7 @@ class Chip(object):
         """ An iterable of available processors
 
         :return: iterable of processors
-        :rtype: iterable of :py:class:spinn_machine.Processor`
+        :rtype: iterable(:py:class:`~spinn_machine.Processor`)
         :raise None: does not raise any known exceptions
         """
         return itervalues(self._p)
@@ -162,17 +159,17 @@ class Chip(object):
         """ The router object associated with the chip
 
         :return: router associated with the chip
-        :rtype: :py:class:`spinn_machine.Router`
+        :rtype: :py:class:`~spinn_machine.Router`
         :raise None: does not raise any known exceptions
         """
         return self._router
 
     @property
     def sdram(self):
-        """ The sdram associated with the chip
+        """ The SDRAM associated with the chip
 
-        :return: sdram associated with the chip
-        :rtype: :py:class:`spinn_machine.SDRAM`
+        :return: SDRAM associated with the chip
+        :rtype: :py:class:`~spinn_machine.SDRAM`
         :raise None: does not raise any known exceptions
         """
         return self._sdram
@@ -190,9 +187,9 @@ class Chip(object):
 
     @property
     def nearest_ethernet_x(self):
-        """ the x coord of the nearest Ethernet chip
+        """ the x coordinate of the nearest Ethernet chip
 
-        :return: the x coord of the nearest Ethernet chip
+        :return: the x coordinate of the nearest Ethernet chip
         :rtype: int
         :raise None: does not raise any known exceptions
         """
@@ -200,9 +197,9 @@ class Chip(object):
 
     @property
     def nearest_ethernet_y(self):
-        """ the y coord of the nearest Ethernet chip
+        """ the y coordinate of the nearest Ethernet chip
 
-        :return: the y coord of the nearest Ethernet chip
+        :return: the y coordinate of the nearest Ethernet chip
         :rtype: int
         :raise None: does not raise any known exceptions
         """
@@ -210,9 +207,9 @@ class Chip(object):
 
     @property
     def tag_ids(self):
-        """ The tag ids supported by this chip
+        """ The tag IDs supported by this chip
 
-        :return: the set of ids.
+        :return: the set of IDs.
         :raise None: this method does not raise any exception
         """
         return self._tag_ids
@@ -233,10 +230,10 @@ class Chip(object):
 
         .. warning::
             This method should ONLY be called via\
-            Machine.reserve_system_processors
+            :py:meth:`spinn_machine.Machine.reserve_system_processors`
 
         :return:\
-            The id of the processor reserved, or None if no processor could\
+            The ID of the processor reserved, or None if no processor could\
             be found
         :rtype: int or None
         """
@@ -253,9 +250,9 @@ class Chip(object):
         """ Get an iterable of processor identifiers and processors
 
         :return: An iterable of (processor_id, processor) where:
-            * processor_id is the id of a processor
-            * processor is the processor with the id
-        :rtype: iterable of (int, :py:class:spinn_machine.Processor`)
+            * processor_id is the ID of a processor
+            * processor is the processor with the ID
+        :rtype: iterable(int,:py:class:`~spinn_machine.Processor`)
         :raise None: does not raise any known exceptions
         """
         return iteritems(self._p)

--- a/spinn_machine/core_subset.py
+++ b/spinn_machine/core_subset.py
@@ -2,7 +2,7 @@ from spinn_utilities.ordered_set import OrderedSet
 
 
 class CoreSubset(object):
-    """ Represents a subset of the cores on a chip
+    """ Represents a subset of the cores on a SpiNNaker chip.
     """
 
     __slots__ = (
@@ -15,8 +15,8 @@ class CoreSubset(object):
         :type x: int
         :param y: The y-coordinate of the chip
         :type y: int
-        :param processor_ids: An iterable of processor ids on the chip
-        :type processor_ids: iterable of int
+        :param processor_ids: An iterable of processor IDs on the chip
+        :type processor_ids: iterable(int)
         """
         self._x = x
         self._y = y
@@ -25,9 +25,9 @@ class CoreSubset(object):
             self.add_processor(processor_id)
 
     def add_processor(self, processor_id):
-        """ Adds a processor id to this subset
+        """ Adds a processor ID to this subset
 
-        :param processor_id: A processor id
+        :param processor_id: A processor ID
         :type processor_id: int
         :return: Nothing is returned
         :rtype: None
@@ -57,10 +57,10 @@ class CoreSubset(object):
 
     @property
     def processor_ids(self):
-        """ The subset of processor ids on the chip
+        """ The subset of processor IDs on the chip
 
-        :return: An iterable of processor ids
-        :rtype: iterable of int
+        :return: An iterable of processor IDs
+        :rtype: iterable(int)
         """
         return iter(self._processor_ids)
 

--- a/spinn_machine/core_subsets.py
+++ b/spinn_machine/core_subsets.py
@@ -4,7 +4,8 @@ from .core_subset import CoreSubset
 
 
 class CoreSubsets(object):
-    """ Represents a group of CoreSubsets, with a maximum of one per chip
+    """ Represents a group of CoreSubsets, with a maximum of one per\
+        SpiNNaker chip.
     """
 
     __slots__ = ("_core_subsets", )
@@ -12,8 +13,7 @@ class CoreSubsets(object):
     def __init__(self, core_subsets=None):
         """
         :param core_subsets: An iterable of cores for each desired chip
-        :type core_subsets: iterable of\
-            :py:class:`spinn_machine.CoreSubset`
+        :type core_subsets: iterable(:py:class:`~spinn_machine.CoreSubset`)
         """
         self._core_subsets = OrderedDict()
         if core_subsets is not None:
@@ -25,7 +25,6 @@ class CoreSubsets(object):
 
         :param core_subset: The core subset to add
         :type core_subset: :py:class:`spinn_machine.CoreSubset`
-        :return: Nothing is returned
         :rtype: None
         """
         xy = (core_subset.x, core_subset.y)
@@ -51,9 +50,8 @@ class CoreSubsets(object):
         :type x: int
         :param y: The y-coordinate of the chip
         :type y: int
-        :param processor_id: A processor id
+        :param processor_id: A processor ID
         :type processor_id: int
-        :return: Nothing is returned
         :rtype: None
         """
         xy = (x, y)
@@ -81,7 +79,7 @@ class CoreSubsets(object):
         :type x: int
         :param y: The y-coordinate of a chip
         :type y: int
-        :param processor_id: The id of a core
+        :param processor_id: The ID of a core
         :type processor_id: int
         :return: Whether there is a chip with coordinates (x, y) in the\
             subset, which has a core with the given id in the subset
@@ -96,7 +94,7 @@ class CoreSubsets(object):
         """ The one-per-chip subsets
 
         :return: Iterable of core subsets
-        :rtype: iterable of :py:class:`spinn_machine.CoreSubset`
+        :rtype: iterable(:py:class:`spinn_machine.CoreSubset`)
         """
         return itervalues(self._core_subsets)
 
@@ -108,7 +106,7 @@ class CoreSubsets(object):
         :param y: The y-coordinate of a chip
         :type y: int
         :return: The core subset of a chip, which will be empty if not added
-        :rtype: :py:class:`spinn_machine.CoreSubset`
+        :rtype: :py:class:`~spinn_machine.CoreSubset`
         """
         xy = (x, y)
         if xy not in self._core_subsets:
@@ -131,6 +129,7 @@ class CoreSubsets(object):
         :param x_y_tuple:\
             Either a 2-tuple of x, y coordinates or a 3-tuple or x, y,\
             processor_id coordinates
+        :type x_y_tuple: tuple(int,int) or tuple(int,int,int)
         """
         if len(x_y_tuple) == 2:
             return self.is_chip(*x_y_tuple)

--- a/spinn_machine/exceptions.py
+++ b/spinn_machine/exceptions.py
@@ -12,7 +12,6 @@ class SpinnMachineAlreadyExistsException(SpinnMachineException):
 
     def __init__(self, item, value):
         """
-
         :param item: The item of which there is already one of
         :type item: str
         :param value: The value of the item
@@ -47,7 +46,6 @@ class SpinnMachineInvalidParameterException(SpinnMachineException):
 
     def __init__(self, parameter, value, problem):
         """
-
         :param parameter: The name of the parameter that has an invalid value
         :type parameter: str
         :param value: The value of the parameter that is invalid

--- a/spinn_machine/fixed_route_entry.py
+++ b/spinn_machine/fixed_route_entry.py
@@ -3,6 +3,8 @@ from .exceptions import SpinnMachineAlreadyExistsException
 
 
 class FixedRouteEntry(object):
+    """ Describes an entry in a SpiNNaker chip's fixed route routing table.
+    """
 
     __slots__ = (
 
@@ -32,19 +34,19 @@ class FixedRouteEntry(object):
 
     @property
     def processor_ids(self):
-        """ The destination processor ids
+        """ The destination processor IDs
 
-        :return: An iterable of processor ids
-        :rtype: iterable of int
+        :return: An iterable of processor IDs
+        :rtype: iterable(int)
         """
         return self._processor_ids
 
     @property
     def link_ids(self):
-        """ The destination link ids
+        """ The destination link IDs
 
-        :return: An iterable of link ids
-        :rtype: iterable of int
+        :return: An iterable of link IDs
+        :rtype: iterable(int)
         """
         return self._link_ids
 

--- a/spinn_machine/link.py
+++ b/spinn_machine/link.py
@@ -5,7 +5,7 @@ from .exceptions import SpinnMachineAlreadyExistsException
 
 
 class Link(object):
-    """ Represents a directional link between chips in the machine
+    """ Represents a directional link between SpiNNaker chips in the machine
     """
 
     __slots__ = (
@@ -17,12 +17,11 @@ class Link(object):
     def __init__(self, source_x, source_y, source_link_id, destination_x,
                  destination_y, multicast_default_from, multicast_default_to):
         """
-
         :param source_x: The x-coordinate of the source chip of the link
         :type source_x: int
         :param source_y: The y-coordinate of the source chip of the link
         :type source_y: int
-        :param source_link_id: The id of the link in the source chip
+        :param source_link_id: The ID of the link in the source chip
         :type source_link_id: int
         :param destination_x: \
             The x-coordinate of the destination chip of the link
@@ -74,9 +73,9 @@ class Link(object):
 
     @property
     def source_link_id(self):
-        """ The id of the link on the source chip
+        """ The ID of the link on the source chip
 
-        :return: The link id
+        :return: The link ID
         :rtype: int
         """
         return self._source_link_id
@@ -101,19 +100,19 @@ class Link(object):
 
     @property
     def multicast_default_from(self):
-        """ The id of the link for which this link is the default
+        """ The ID of the link for which this link is the default
 
-        :return: The id of a link, or None if no such link
+        :return: The ID of a link, or None if no such link
         :rtype: int
         """
         return self._multicast_default_from
 
     @multicast_default_from.setter
     def multicast_default_from(self, multicast_default_from):
-        """ Sets the id of the link for which this link is the default,\
+        """ Sets the ID of the link for which this link is the default,\
             if not already set
 
-        :param multicast_default_from: The id of a link
+        :param multicast_default_from: The ID of a link
         :type multicast_default_from: int
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
             If a value has already been set
@@ -125,18 +124,18 @@ class Link(object):
 
     @property
     def multicast_default_to(self):
-        """ The id of the link to which to send default routed multicast
+        """ The ID of the link to which to send default routed multicast
 
-        :return: The id of a link, or None if no such link
+        :return: The ID of a link, or None if no such link
         :rtype: int
         """
         return self._multicast_default_to
 
     @multicast_default_to.setter
     def multicast_default_to(self, multicast_default_to):
-        """ Sets the id of the link to which to send default routed multicast
+        """ Sets the ID of the link to which to send default routed multicast
 
-        :param multicast_default_to: The id of a link
+        :param multicast_default_to: The ID of a link
         :type multicast_default_to: int
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
             If a value has already been set

--- a/spinn_machine/link_data_objects/abstract_link_data.py
+++ b/spinn_machine/link_data_objects/abstract_link_data.py
@@ -1,5 +1,5 @@
 class AbstractLinkData(object):
-    """ Data object for spinnaker links
+    """ Data object for SpiNNaker links
     """
 
     __slots__ = (

--- a/spinn_machine/link_data_objects/spinnaker_link_data.py
+++ b/spinn_machine/link_data_objects/spinnaker_link_data.py
@@ -17,7 +17,7 @@ class SpinnakerLinkData(AbstractLinkData):
 
     @property
     def spinnaker_link_id(self):
-        """ The ID of the spinnaker link.
+        """ The ID of the SpiNNaker link.
         """
         return self._spinnaker_link_id
 

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -9,8 +9,8 @@ from six import iteritems, iterkeys, itervalues
 
 
 class Machine(object):
-    """ A Representation of a Machine with a number of Chips.  Machine is also\
-        iterable, providing ((x, y), chip) where:
+    """ A representation of a SpiNNaker Machine with a number of Chips.\
+        Machine is also iterable, providing ((x, y), chip) where:
 
             * x is the x-coordinate of a chip
             * y is the y-coordinate of a chip
@@ -57,7 +57,7 @@ class Machine(object):
     def __init__(self, chips, boot_x, boot_y):
         """
         :param chips: An iterable of chips in the machine
-        :type chips: iterable of :py:class:`spinn_machine.Chip`
+        :type chips: iterable of :py:class:`~spinn_machine.Chip`
         :param boot_x: The x-coordinate of the chip used to boot the machine
         :type boot_x: int
         :param boot_y: The y-coordinate of the chip used to boot the machine
@@ -97,7 +97,7 @@ class Machine(object):
         """ Add a chip to the machine
 
         :param chip: The chip to add to the machine
-        :type chip: :py:class:`spinn_machine.Chip`
+        :type chip: :py:class:`~spinn_machine.Chip`
         :return: Nothing is returned
         :rtype: None
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
@@ -127,7 +127,7 @@ class Machine(object):
         """ Add some chips to the machine
 
         :param chips: an iterable of chips
-        :type chips: iterable of :py:class:`spinn_machine.Chip`
+        :type chips: iterable(:py:class:`~spinn_machine.Chip`)
         :return: Nothing is returned
         :rtype: None
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
@@ -142,7 +142,7 @@ class Machine(object):
         """ An iterable of chips in the machine
 
         :return: An iterable of chips
-        :rtype: iterable of :py:class:`spinn_machine.Chip`
+        :rtype: iterable(:py:class:`~spinn_machine.Chip`)
         :raise None: does not raise any known exceptions
         """
         return itervalues(self._chips)
@@ -152,7 +152,7 @@ class Machine(object):
         """ An iterable of chip coordinates in the machine
 
         :return: An iterable of chip coordinates
-        :rtype: iterable of (int, int)
+        :rtype: iterable(int,int)
         """
         return iterkeys(self._chips)
 
@@ -164,7 +164,7 @@ class Machine(object):
                 * x is the x-coordinate of a chip
                 * y is the y-coordinate of a chip
             * chip is a chip
-        :rtype: iterable of ((int, int), :py:class:`spinn_machine.Chip`)
+        :rtype: iterable((int, int), :py:class:`~spinn_machine.Chip`)
         :raise None: does not raise any known exceptions
         """
         return iteritems(self._chips)
@@ -186,7 +186,7 @@ class Machine(object):
         :param y: the y-coordinate of the requested chip
         :type y: int
         :return: the chip at the specified location, or None if no such chip
-        :rtype: :py:class:`spinn_machine.Chip`
+        :rtype: :py:class:`~spinn_machine.Chip`
         :raise None: does not raise any known exceptions
         """
         chip_id = (x, y)
@@ -202,7 +202,7 @@ class Machine(object):
             * y is the y-coordinate of the chip to retrieve
         :type x_y_tuple: (int, int)
         :return: the chip at the specified location, or None if no such chip
-        :rtype: :py:class:`spinn_machine.Chip`
+        :rtype: :py:class:`~spinn_machine.Chip`
         :raise None: does not raise any known exceptions
         """
         x, y = x_y_tuple
@@ -240,7 +240,7 @@ class Machine(object):
         :param x_y_tuple: A tuple of (x, y) where:
             * x is the x-coordinate of the chip to retrieve
             * y is the y-coordinate of the chip to retrieve
-        :type x_y_tuple: (int, int)
+        :type x_y_tuple: tuple(int, int)
         :return: True if the chip exists, False otherwise
         :rtype: bool
         :raise None: does not raise any known exceptions
@@ -275,7 +275,7 @@ class Machine(object):
         """ The chips in the machine that have an Ethernet connection
 
         :return: An iterable of chips
-        :rtype: iterable of :py:class:`spinn_machine.Chip`
+        :rtype: iterable of :py:class:`~spinn_machine.Chip`
         """
         return self._ethernet_connected_chips
 
@@ -285,22 +285,22 @@ class Machine(object):
 
         :return: An iterable of spinnaker links
         :rtype: iterable of\
-            :py:class:`spinn_machine.link_data_objects.SpinnakerLinkData`
+            :py:class:`~spinn_machine.link_data_objects.SpinnakerLinkData`
         """
         return iteritems(self._spinnaker_links)
 
     def get_spinnaker_link_with_id(
             self, spinnaker_link_id, board_address=None):
-        """ Get a spinnaker link with a given id
+        """ Get a SpiNNaker link with a given ID
 
-        :param spinnaker_link_id: The id of the link
+        :param spinnaker_link_id: The ID of the link
         :type spinnaker_link_id: int
         :param board_address:\
-            the board address that this spinnaker link is associated with
+            the board address that this SpiNNaker link is associated with
         :type board_address: str or None
-        :return: The spinnaker link data or None if no link
+        :return: The SpiNNaker link data or None if no link
         :rtype:\
-            :py:class:`spinn_machine.link_data_objects.SpinnakerLinkData`
+            :py:class:`~spinn_machine.link_data_objects.SpinnakerLinkData`
         """
         if board_address is None:
             board_address = self._boot_ethernet_address
@@ -312,20 +312,20 @@ class Machine(object):
             link for a given board address.
 
         :param fpga_id:\
-            the id of the FPGA that the data is going through.  Refer to \
+            the ID of the FPGA that the data is going through.  Refer to \
             technical document located here for more detail:
             https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
         :type fpga_link_id: int
         :param fpga_link_id:\
-            the link id of the FPGA. Refer to technical document located here\
+            the link ID of the FPGA. Refer to technical document located here\
             for more detail:
             https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
         :type fpga_id: int
         :param board_address:\
-            the board address that this spinnaker link is associated with
+            the board address that this FPGA link is associated with
         :type board_address: str
         :rtype:\
-            :py:class:`spinn_machine.link_data_objects.FPGALinkData`
+            :py:class:`~spinn_machine.link_data_objects.FPGALinkData`
         :return: the given FPGA link object or None if no such link
         """
         if board_address is None:
@@ -539,6 +539,7 @@ class Machine(object):
         """ Get the number of cores and links from the machine
 
         :return: tuple of (n_cores, n_links)
+        :rtype: tuple(int,int)
         """
         cores = 0
         total_links = dict()
@@ -582,7 +583,7 @@ class Machine(object):
     def boot_chip(self):
         """ The chip used to boot the machine
 
-        :rtype: `py:class:spinn_machine.Chip`
+        :rtype: `~py:class:spinn_machine.Chip`
         """
         return self._chips[self._boot_x, self._boot_y]
 
@@ -591,6 +592,7 @@ class Machine(object):
 
         :param chip: The chip to find other chips on the same board as
         :return: An iterable of (x, y) coordinates of chips on the same board
+        :rtype: iterable(tuple(int,int))
         """
         eth_x = chip.nearest_ethernet_x
         eth_y = chip.nearest_ethernet_y
@@ -621,8 +623,8 @@ class Machine(object):
             A CoreSubsets of reserved cores, and a list of (x, y) of chips\
             where a non-system core was not available
         :rtype:\
-            (:py:class:`spinn_machine.CoreSubsets`,\
-            list of (int, int))
+            tuple(:py:class:`~spinn_machine.CoreSubsets`,\
+            list(int, int))
         """
         self._maximum_user_cores_on_chip = 0
         reserved_cores = CoreSubsets()
@@ -650,7 +652,7 @@ class Machine(object):
 
     @property
     def total_available_user_cores(self):
-        """ provides total number of cores on the machine which are not \
+        """ The total number of cores on the machine which are not \
             monitor cores
 
         :return: total
@@ -662,7 +664,7 @@ class Machine(object):
 
     @property
     def total_cores(self):
-        """ provides total number of cores on the machine, includes monitors
+        """ The total number of cores on the machine, including monitors
 
         :return: total
         :rtype: int

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -4,7 +4,7 @@ from .exceptions import SpinnMachineInvalidParameterException
 
 
 class MulticastRoutingEntry(object):
-    """ Represents an entry in a multicast routing table
+    """ Represents an entry in a SpiNNaker chip's multicast routing table
     """
 
     __slots__ = (
@@ -20,10 +20,10 @@ class MulticastRoutingEntry(object):
         :type routing_entry_key: int
         :param mask: The route key_combo mask
         :type mask: int
-        :param processor_ids: The destination processor ids
-        :type processor_ids: iterable of int
-        :param link_ids: The destination link ids
-        :type link_ids: iterable of int
+        :param processor_ids: The destination processor IDs
+        :type processor_ids: iterable(int)
+        :param link_ids: The destination link IDs
+        :type link_ids: iterable(int)
         :param defaultable: if this entry is defaultable (it receives packets \
             from its directly opposite route position)
         :type defaultable: bool
@@ -79,19 +79,19 @@ class MulticastRoutingEntry(object):
 
     @property
     def processor_ids(self):
-        """ The destination processor ids
+        """ The destination processor IDs
 
-        :return: An iterable of processor ids
-        :rtype: iterable of int
+        :return: An iterable of processor IDs
+        :rtype: iterable(int)
         """
         return self._processor_ids
 
     @property
     def link_ids(self):
-        """ The destination link ids
+        """ The destination link IDs
 
-        :return: An iterable of link ids
-        :rtype: iterable of int
+        :return: An iterable of link IDs
+        :rtype: iterable(int)
         """
         return self._link_ids
 
@@ -107,15 +107,15 @@ class MulticastRoutingEntry(object):
     def merge(self, other_entry):
         """ Merges together two multicast routing entries.  The entry to merge\
             must have the same key and mask.  The merge will join the\
-            processor ids and link ids from both the entries.  This could be\
+            processor IDs and link IDs from both the entries.  This could be\
             used to add a new destination to an existing route in a\
             routing table. It is also possible to use the add (+) operator or\
             the or (|) operator with the same effect.
 
         :param other_entry: The multicast entry to merge with this entry
-        :type other_entry: :py:class:`MulticastRoutingEntry`
+        :type other_entry: :py:class:`~spinn_machine.MulticastRoutingEntry`
         :return: A new multicast routing entry with merged destinations
-        :rtype: :py:class:`MulticastRoutingEntry`
+        :rtype: :py:class:`~spinn_machine.MulticastRoutingEntry`
         :raise spinn_machine.exceptions.SpinnMachineInvalidParameterException:\
             If the key and mask of the other entry do not match
         """
@@ -153,10 +153,6 @@ class MulticastRoutingEntry(object):
         return self.merge(other_entry)
 
     def __eq__(self, other_entry):
-        """ support for comparisons
-
-        :param other_entry: other Multicast_routing_entry
-        """
         if not isinstance(other_entry, MulticastRoutingEntry):
             return False
         return (self._defaultable == other_entry.defaultable and

--- a/spinn_machine/processor.py
+++ b/spinn_machine/processor.py
@@ -2,7 +2,7 @@ from .exceptions import SpinnMachineInvalidParameterException
 
 
 class Processor(object):
-    """ A processor object included in a chip
+    """ A processor object included in a SpiNNaker chip
     """
 
     CLOCK_SPEED = 200 * 1000 * 1000
@@ -15,10 +15,10 @@ class Processor(object):
     def __init__(self, processor_id, clock_speed=CLOCK_SPEED, is_monitor=False,
                  dtcm_available=DTCM_AVAILABLE):
         """
-        :param processor_id: id of the processor in the chip
+        :param processor_id: ID of the processor in the chip
         :type processor_id: int
         :param clock_speed: \
-            The number of cpu cycles per second of the processor
+            The number of CPU cycles per second of the processor
         :type clock_speed: int
         :param is_monitor: Determines if the processor is considered the\
             monitor processor, and so should not be otherwise allocated
@@ -41,9 +41,9 @@ class Processor(object):
 
     @property
     def processor_id(self):
-        """ The id of the processor
+        """ The ID of the processor
 
-        :return: id of the processor
+        :return: ID of the processor
         :rtype: int
         """
         return self._processor_id
@@ -60,9 +60,9 @@ class Processor(object):
 
     @property
     def cpu_cycles_available(self):
-        """ The number of cpu cycles available from this processor per ms
+        """ The number of CPU cycles available from this processor per ms
 
-        :return: the number of cpu cycles available on this processor
+        :return: the number of CPU cycles available on this processor
         :rtype: int
         """
         return self._clock_speed / 1000.0
@@ -96,9 +96,9 @@ class Processor(object):
         """ Creates a clone of this processor but changing it to a system\
             processor.
 
-        :return: A new Processor with the same properties INCLUDING id\
+        :return: A new Processor with the same properties INCLUDING the ID\
             except now set as a System processor
-        :rtype: spinn_machine.Processor
+        :rtype: :py:class:`~spinn_machine.Processor`
         """
         return Processor(self._processor_id, self._clock_speed,
                          is_monitor=True, dtcm_available=self._dtcm_available)

--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -10,8 +10,8 @@ class Router(object):
         The router is iterable over the links, providing (source_link_id,\
         link) where:
 
-            * source_link_id is the id of a link
-            * link is the link with id source_link_id
+            * source_link_id is the ID of a link
+            * link is the link with ID source_link_id
     """
 
     ROUTER_DEFAULT_AVAILABLE_ENTRIES = 1024
@@ -31,7 +31,7 @@ class Router(object):
             n_available_multicast_entries=ROUTER_DEFAULT_AVAILABLE_ENTRIES):
         """
         :param links: iterable of links
-        :type links: iterable of :py:class:`spinn_machine.Link`
+        :type links: iterable(:py:class:`~spinn_machine.Link`)
         :param emergency_routing_enabled: \
             Determines if the router emergency routing is operating
         :type emergency_routing_enabled: bool
@@ -67,12 +67,12 @@ class Router(object):
         self._links[link.source_link_id] = link
 
     def is_link(self, source_link_id):
-        """ Determine if there is a link with id source_link_id.\
-            Also implemented as __contains__(source_link_id)
+        """ Determine if there is a link with ID source_link_id.\
+            Also implemented as `__contains__(source_link_id)`
 
-        :param source_link_id: The id of the link to find
+        :param source_link_id: The ID of the link to find
         :type source_link_id: int
-        :return: True if there is a link with the given id, False otherwise
+        :return: True if there is a link with the given ID, False otherwise
         :rtype: bool
         :raise None: No known exceptions are raised
         """
@@ -84,13 +84,13 @@ class Router(object):
         return self.is_link(source_link_id)
 
     def get_link(self, source_link_id):
-        """ Get the link with the given id, or None if no such link.\
-            Also implemented as __getitem__(source_link_id)
+        """ Get the link with the given ID, or None if no such link.\
+            Also implemented as `__getitem__(source_link_id)`
 
-        :param source_link_id: The id of the link to find
+        :param source_link_id: The ID of the link to find
         :type source_link_id: int
         :return: The link, or None if no such link
-        :rtype: :py:class:`spinn_machine.Link`
+        :rtype: :py:class:`~spinn_machine.Link`
         :raise None: No known exceptions are raised
         """
         if source_link_id in self._links:
@@ -107,18 +107,18 @@ class Router(object):
         """ The available links of this router
 
         :return: an iterable of available links
-        :rtype: iterable of :py:class:`spinn_machine.Link`
+        :rtype: iterable(:py:class:`~spinn_machine.Link`)
         :raise None: does not raise any known exceptions
         """
         return itervalues(self._links)
 
     def __iter__(self):
-        """ Get an iterable of source link ids and links in the router
+        """ Get an iterable of source link IDs and links in the router
 
         :return: an iterable of tuples of (source_link_id, link) where:
-            * source_link_id is the id of the link
+            * source_link_id is the ID of the link
             * link is a router link
-        :rtype: iterable of (int, :py:class:`spinn_machine.Link`)
+        :rtype: iterable(int, :py:class:`~spinn_machine.Link`)
         :raise None: does not raise any known exceptions
         """
         return iteritems(self._links)
@@ -168,7 +168,7 @@ class Router(object):
 
         :param routing_table_entry: The entry to convert
         :type routing_table_entry:\
-            :py:class:`spinn_machine.MulticastRoutingEntry`
+            :py:class:`~spinn_machine.MulticastRoutingEntry`
         :rtype: int
         """
         route_entry = 0
@@ -177,7 +177,7 @@ class Router(object):
                 raise SpinnMachineInvalidParameterException(
                     "route.processor_ids",
                     str(routing_table_entry.processor_ids),
-                    "Processor ids must be between 0 and 26")
+                    "Processor IDs must be between 0 and 26")
             route_entry |= (1 << (6 + processor_id))
         for link_id in routing_table_entry.link_ids:
             if link_id > 5 or link_id < 0:
@@ -191,7 +191,7 @@ class Router(object):
         """ Utility method to convert links into x and y coordinates
 
         :return: iterable list of destination coordinates in x and y dict
-        :rtype: iterable of dict
+        :rtype: iterable(dict(str,int))
 
         """
         next_hop_chips_coords = list()

--- a/spinn_machine/spinnaker_triad_geometry.py
+++ b/spinn_machine/spinnaker_triad_geometry.py
@@ -20,7 +20,7 @@ class SpiNNakerTriadGeometry(object):
     def get_spinn5_geometry():
         """ Get the geometry object for a SpiNN-5 arrangement of boards
 
-        :return: a SpiNNakerTriadGeometry object.
+        :return: a :py:class:`SpiNNakerTriadGeometry` object.
         """
 
         # Note the centres are slightly offset so as to force which edges are

--- a/spinn_machine/tags/abstract_tag.py
+++ b/spinn_machine/tags/abstract_tag.py
@@ -1,7 +1,9 @@
 class AbstractTag(object):
+    """ Common properties of SpiNNaker IP tags and reverse IP tags.
+    """
 
     __slots__ = [
-        # the board address associted with this tag
+        # the board address associated with this tag
         "_board_address",
 
         # the tag id associated with this tag
@@ -24,7 +26,7 @@ class AbstractTag(object):
 
     @property
     def tag(self):
-        """ The tag id of the tag
+        """ The tag ID of the tag
         """
         return self._tag
 

--- a/spinn_machine/tags/iptag.py
+++ b/spinn_machine/tags/iptag.py
@@ -20,7 +20,7 @@ class IPTag(AbstractTag):
             port=None, strip_sdp=False, traffic_identifier="DEFAULT"):
         """
         :param board_address: \
-            The ip address of the board on which the tag is allocated
+            The IP address of the board on which the tag is allocated
         :type board_address: str or None
         :param destination_x: \
             The x-coordinate where users of this tag should send packets to
@@ -34,8 +34,9 @@ class IPTag(AbstractTag):
             The IP address to which SDP packets with the tag will be sent
         :type ip_address: str
         :param port: \
-            The port to which the SDP packets with the tag will be sent
-        :type port: int or None if not yet assigned
+            The port to which the SDP packets with the tag will be sent, or\
+            None if not yet assigned
+        :type port: int or None
         :param strip_sdp: Indicates whether the SDP header should be removed
         :type strip_sdp: bool
         :param traffic_identifier: \

--- a/spinn_machine/tags/reverse_iptag.py
+++ b/spinn_machine/tags/reverse_iptag.py
@@ -2,7 +2,7 @@ from .abstract_tag import AbstractTag
 
 
 class ReverseIPTag(AbstractTag):
-    """ Used to hold data that is contained within an IPTag
+    """ Used to hold data that is contained within a Reverse IPTag
     """
 
     __slots__ = [
@@ -17,7 +17,7 @@ class ReverseIPTag(AbstractTag):
                  destination_p, sdp_port=1):
         """
         :param board_address: \
-            The ip address of the board on which the tag is allocated
+            The IP address of the board on which the tag is allocated
         :type board_address: str or None
         :param tag: The tag of the SDP packet
         :type tag: int
@@ -27,7 +27,7 @@ class ReverseIPTag(AbstractTag):
         :type destination_x: int
         :param destination_y: The y-coordinate of the chip to send packets to
         :type destination_y: int
-        :param destination_p: The id of the processor to send packets to
+        :param destination_p: The ID of the processor to send packets to
         :type destination_p: int
         :param sdp_port: The optional port number to use for SDP packets that\
             are formed on the machine (default is 1)
@@ -63,7 +63,7 @@ class ReverseIPTag(AbstractTag):
 
     @property
     def destination_p(self):
-        """ The destination processor id for the chip at (x,y) that packets\
+        """ The destination processor ID for the chip at (x,y) that packets\
             should be send to for this reverse IP tag
         """
         return self._destination_p

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -52,7 +52,7 @@ class VirtualMachine(Machine):
         :type height: int
         :param with_wrap_arounds: bool defining if wrap around links exist
         :type with_wrap_arounds: bool
-        :param version: the version id of a board; if None, a machine is\
+        :param version: the version ID of a board; if None, a machine is\
             created with the correct dimensions, otherwise the machine will be\
             a single board of the given version.
         :type version: int
@@ -264,7 +264,7 @@ class VirtualMachine(Machine):
         """ Add a chip to the machine
 
         :param chip: The chip to add to the machine
-        :type chip: :py:class:`spinn_machine.Chip`
+        :type chip: :py:class:`~spinn_machine.Chip`
         :return: Nothing is returned
         :rtype: None
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \


### PR DESCRIPTION
Does a bunch of fixes in the documentation, using correct capitalisation for abbreviations and so on.

NB: <code>:py:class:\`~spinn_machine.Chip\`</code> formats as [`Chip`](/link-to-the-chip-docs) (except with the correct link, of course) so that's what I've converted internal links to use.