### PR TITLE
removes dead code from when we allocated reinjector as a monitor core

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -231,29 +231,6 @@ class Chip(object):
             if not processor.is_monitor:
                 return processor
 
-    def reserve_a_system_processor(self):
-        """ Sets one of the none monitor processors as a system processor.
-
-        Updates n_user_processors
-
-        .. warning::
-            This method should ONLY be called via\
-            :py:meth:`spinn_machine.Machine.reserve_system_processors`
-
-        :return:\
-            The ID of the processor reserved, or None if no processor could\
-            be found
-        :rtype: int or None
-        """
-        for processor_id, processor in iteritems(self._p):
-            if not processor.is_monitor:
-                system_processor = processor.clone_as_system_processor()
-                self._p[processor_id] = system_processor
-                self._n_user_processors -= 1
-                return processor_id
-
-        return None
-
     def __iter__(self):
         """ Get an iterable of processor identifiers and processors
 

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from six import iteritems, iterkeys, itervalues
 from .exceptions import SpinnMachineAlreadyExistsException
-from .core_subsets import CoreSubsets
 from spinn_machine.link_data_objects import FPGALinkData, SpinnakerLinkData
 
 

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -609,37 +609,6 @@ class Machine(object):
                         (chip_x, chip_y) not in Machine.BOARD_48_CHIP_GAPS):
                     yield x, y
 
-    def reserve_system_processors(self):
-        """ Sets one of the none monitor system processors as a system\
-            processor on every Chip
-
-        Updates maximum_user_cores_on_chip
-
-        :return:\
-            A CoreSubsets of reserved cores, and a list of (x, y) of chips\
-            where a non-system core was not available
-        :rtype:\
-            tuple(:py:class:`~spinn_machine.CoreSubsets`,\
-            list(int, int))
-        """
-        self._maximum_user_cores_on_chip = 0
-        reserved_cores = CoreSubsets()
-        failed_chips = list()
-        for chip in itervalues(self._chips):
-
-            # Try to get a new system processor
-            core_reserved = chip.reserve_a_system_processor()
-            if core_reserved is None:
-                failed_chips.append((chip.x, chip.y))
-            else:
-                reserved_cores.add_processor(chip.x, chip.y, core_reserved)
-
-            # Update the maximum user cores either way
-            if chip.n_user_processors > self._maximum_user_cores_on_chip:
-                self._maximum_user_cores_on_chip = chip.n_user_processors
-
-        return reserved_cores, failed_chips
-
     @property
     def maximum_user_cores_on_chip(self):
         """ The maximum number of user cores on any chip

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -447,33 +447,6 @@ class VirtualMachine(Machine):
             return False
         return (source_x, source_y, link_from) not in self._down_links
 
-    def reserve_system_processors(self):
-        """ Sets one of the none monitor system processors as a system\
-            processor on every Chip
-
-        Updates maximum_user_cores_on_chip
-
-        :rtype None
-        """
-        # Handle existing chips
-        reserved_cores, failed_chips = \
-            super(VirtualMachine, self).reserve_system_processors()
-
-        # Go through the remaining cores and get a virtual unused core
-        for x, y in self.chip_coordinates:
-            if (x, y) not in self._chips:
-                for processor_id in range(0, self._with_monitors):
-                    if (x, y, processor_id) not in self._down_cores:
-                        reserved_cores.add_processor(x, y, processor_id)
-                        break
-                else:
-                    failed_chips.append((x, y))
-
-        # Ensure future chips get an extra monitor
-        self._with_monitors += 1
-
-        return reserved_cores, failed_chips
-
     @property
     def maximum_user_cores_on_chip(self):
         return max(self._maximum_user_cores_on_chip,

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -113,30 +113,6 @@ class TestingChip(unittest.TestCase):
             self._create_chip(self._x, self._y, processors, self._router,
                               self._sdram, self._ip)
 
-    def test_reserve_a_system_processor(self):
-        new_chip = self._create_chip(self._x, self._y, self._processors,
-                                     self._router, self._sdram, self._ip)
-        self.assertEquals(new_chip.n_user_processors,
-                          len(self._processors) - 1)
-
-        monitor = new_chip.get_processor_with_id(self._monitor_id)
-        self.assertTrue(monitor.is_monitor)
-
-        for processor in new_chip.processors:
-            self.assertFalse(processor.is_monitor and
-                             processor.processor_id != self._monitor_id)
-
-        new_chip.reserve_a_system_processor()
-        self.assertEquals(new_chip.n_user_processors,
-                          len(self._processors) - 2)
-
-        count = 0
-        for processor in new_chip.processors:
-            if (processor.is_monitor and
-                    (processor.processor_id != self._monitor_id)):
-                count += 1
-        self.assertEquals(count, 1)
-
     def test_get_first_none_monitor_processor(self):
         """ test the get_first_none_monitor_processor
 

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -228,34 +228,6 @@ class SpinnMachineTestCase(unittest.TestCase):
         new_machine = Machine(chips, 0, 0)
         self.assertFalse(new_machine.is_chip_at(10, 0))
 
-    def test_reserve_system_processors(self):
-        processors = self._create_processors()
-        chips = self._create_chips(processors)
-        new_machine = Machine(chips, 0, 0)
-        self.assertEquals(new_machine.maximum_user_cores_on_chip,
-                          len(processors) - 1)
-
-        new_machine.reserve_system_processors()
-        self.assertEquals(new_machine.maximum_user_cores_on_chip,
-                          len(processors) - 2)
-
-    def test_reserve_system_processors_different(self):
-        chips = list()
-        for x in range(2):
-            for y in range(2):
-                processors = self._create_processors(
-                    monitor=1 + x + y, number=5 + x + y)
-                chips.append(self._create_chip(x, y, processors))
-        # processors coming out will be biggest list
-
-        new_machine = Machine(chips, 0, 0)
-        self.assertEquals(new_machine.maximum_user_cores_on_chip,
-                          len(processors) - 1)
-
-        new_machine.reserve_system_processors()
-        self.assertEquals(new_machine.maximum_user_cores_on_chip,
-                          len(processors) - 2)
-
     def test_machine_get_chips_on_board(self):
         chips = self._create_chips()
         new_machine = Machine(chips, 0, 0)

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -316,14 +316,6 @@ class TestVirtualMachine(unittest.TestCase):
             count += 1
         self.assertEqual(count, 4)
 
-    def test_reserve_system_processors_different(self):
-        n_chips = 18
-        vm = VirtualMachine(2, 2, n_cpus_per_chip=n_chips, with_monitors=True)
-        self.assertEqual(vm.maximum_user_cores_on_chip, n_chips - 1)
-
-        vm.reserve_system_processors()
-        self.assertEqual(vm.maximum_user_cores_on_chip, n_chips - 2)
-
     def test_ethernet_chips_exist(self):
         vm = VirtualMachine(width=48, height=24, with_wrap_arounds=True)
         for eth_chip in vm._ethernet_connected_chips:


### PR DESCRIPTION
this came from reviewing the java, where the equiv removals should also be considerede