### PR TITLE
When you get an actual size of sdram use that as the default

### DIFF
--- a/spinn_machine/sdram.py
+++ b/spinn_machine/sdram.py
@@ -17,6 +17,7 @@ class SDRAM(object):
         if size < 0:
             raise SpinnMachineInvalidParameterException(
                 "size", size, "negative sizes are meaningless")
+        SDRAM.DEFAULT_SDRAM_BYTES = size
         self._size = size
 
     @property


### PR DESCRIPTION
Default of 117 * 1024 * 1024 was actually a little lower than what the machine actually reports.

So if we get an actual size lets use it.