### PR TITLE
Accurate vm

### DIFF
--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -51,11 +51,11 @@ class FullWrapMachine(Machine):
             n_cores = Machine.max_cores_per_chip()
             for (x, y) in self._local_xys:
                 # if ethernet_x/y != 0 GIGO mode so ignore ethernet
-                yield x, y, n_cores
+                yield (x, y), n_cores
         else:
             for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
-                yield((x + ethernet_x) % self._width,
-                      (y + ethernet_y) % self._height, n_cores)
+                yield(((x + ethernet_x) % self._width,
+                      (y + ethernet_y) % self._height), n_cores)
 
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -45,6 +45,18 @@ class FullWrapMachine(Machine):
             chip_y = (y + ethernet_y) % self._height
             yield (chip_x, chip_y)
 
+    @overrides(Machine.get_xy_cores_by_ethernet)
+    def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
+        if (self._width == self._height == 2):
+            n_cores = Machine.max_cores_per_chip()
+            for (x, y) in self._local_xys:
+                # if ethernet_x/y != 0 GIGO mode so ignore ethernet
+                yield x, y, n_cores
+        else:
+            for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
+                yield((x + ethernet_x) % self._width,
+                      (y + ethernet_y) % self._height, n_cores)
+
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y) in self._local_xys:

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -45,6 +45,11 @@ class HorizontalWrapMachine(Machine):
             chip_y = (y + ethernet_y)
             yield (chip_x, chip_y)
 
+    @overrides(Machine.get_xy_cores_by_ethernet)
+    def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
+        for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
+            yield((x + ethernet_x) % self._width, (y + ethernet_y), n_cores)
+
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y) in self._local_xys:

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -48,7 +48,7 @@ class HorizontalWrapMachine(Machine):
     @overrides(Machine.get_xy_cores_by_ethernet)
     def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
-            yield((x + ethernet_x) % self._width, (y + ethernet_y), n_cores)
+            yield(((x + ethernet_x) % self._width, (y + ethernet_y)), n_cores)
 
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -53,7 +53,7 @@ class Machine(object):
     #  coordinates down the given link (0-5)
     LINK_ADD_TABLE = [(1, 0), (1, 1), (0, 1), (-1, 0), (-1, -1), (0, -1)]
 
-    CHIPS_PER_BAORD = {
+    CHIPS_PER_BOARD = {
         (0, 0): 18, (0, 1): 18, (0, 2): 18, (0, 3): 18, (1, 0): 18, (1, 1): 17,
         (1, 2): 18, (1, 3): 17, (1, 4): 18, (2, 0): 18, (2, 1): 18, (2, 2): 18,
         (2, 3): 18, (2, 4): 18, (2, 5): 18, (3, 0): 18, (3, 1): 17, (3, 2): 18,
@@ -63,7 +63,7 @@ class Machine(object):
         (5, 7): 18, (6, 2): 18, (6, 3): 18, (6, 4): 18, (6, 5): 18, (6, 6): 18,
         (6, 7): 18, (7, 3): 18, (7, 4): 18, (7, 5): 18, (7, 6): 18, (7, 7): 18
     }
-    BOARD_48_CHIPS = list(CHIPS_PER_BAORD.keys())
+    BOARD_48_CHIPS = list(CHIPS_PER_BOARD.keys())
 
     __slots__ = (
         "_boot_ethernet_address",
@@ -227,6 +227,38 @@ class Machine(object):
             The y coordinate of a (local 0,0) legal ethernet chip
         :return: Yields the (x, y) coordinates of all the potential chips on \
             this board.
+        :rtype: iterable(tuple(int,int))
+        """
+
+    @abstractmethod
+    def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
+        """
+        Yields the potential x,y locations and the typical number of cores
+        of all the chips on the board with this ethernet.
+
+        Includes the Ethernet chip itself.
+
+        Wrap-arounds are handled as appropriate.
+
+        Note: This method does not check if the chip actually exists,
+        nor report the actual number of cores on this chip, as is
+        intended to be called to create the chips.
+
+        The number of cores is based on the 1,000,000 core machine where the
+        board where built with the the 17 core chips placed in the same
+        location on nearly every board.
+
+        Warning: GIGO! This methods assumes that ethernet_x and ethernet_y are
+        the local 0,0 of an existing board, within the width and height of the
+        machine.
+
+        :param ethernet_x: \
+            The x coordinate of a (local 0,0) legal ethernet chip
+        :param ethernet_y: \
+            The y coordinate of a (local 0,0) legal ethernet chip
+        :return: Yields (x, y, n_cores) where x , y are coordinates of all \
+            the potential chips on this board, and n_cores is the typcial \
+            number of cores for a chip in that possition.
         :rtype: iterable(tuple(int,int))
         """
 

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -42,6 +42,19 @@ class NoWrapMachine(Machine):
         for (x, y) in self._local_xys:
             yield (x + ethernet_x, y + ethernet_y)
 
+    @overrides(Machine.get_xy_cores_by_ethernet)
+    def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
+        if (self._width == self._height == 8) or \
+                self.multiple_48_chip_boards():
+            for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
+                # if ethernet_x/y != 0 GIGO mode so ignore ethernet
+                yield (x, y, n_cores)
+        else:
+            # covers 4 chip and weird sizes
+            n_cores = Machine.max_cores_per_chip()
+            for (x, y) in self._local_xys:
+                yield(x + ethernet_x, y + ethernet_y, n_cores)
+
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y) in self._local_xys:

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -48,12 +48,12 @@ class NoWrapMachine(Machine):
                 self.multiple_48_chip_boards():
             for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
                 # if ethernet_x/y != 0 GIGO mode so ignore ethernet
-                yield (x, y, n_cores)
+                yield ((x + ethernet_x, y + ethernet_y), n_cores)
         else:
-            # covers 4 chip and weird sizes
+            # covers weird sizes
             n_cores = Machine.max_cores_per_chip()
             for (x, y) in self._local_xys:
-                yield(x + ethernet_x, y + ethernet_y, n_cores)
+                yield((x, y), n_cores)
 
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -44,6 +44,11 @@ class VerticalWrapMachine(Machine):
             chip_y = (y + ethernet_y) % self._height
             yield (chip_x, chip_y)
 
+    @overrides(Machine.get_xy_cores_by_ethernet)
+    def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
+        for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
+            yield((x + ethernet_x), (y + ethernet_y) % self._height, n_cores)
+
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y) in self._local_xys:

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -47,7 +47,7 @@ class VerticalWrapMachine(Machine):
     @overrides(Machine.get_xy_cores_by_ethernet)
     def get_xy_cores_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
-            yield((x + ethernet_x), (y + ethernet_y) % self._height, n_cores)
+            yield(((x + ethernet_x), (y + ethernet_y) % self._height), n_cores)
 
     @overrides(Machine.get_chips_by_ethernet)
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -80,9 +80,6 @@ def virtual_machine(
     :rtype: Machine
     """
 
-    if n_cpus_per_chip is None:
-        n_cpus_per_chip = Machine.max_cores_per_chip()
-
     factory = _VirtualMachine(
         width, height, n_cpus_per_chip,  sdram_per_chip,
         down_chips, down_cores, down_links,
@@ -97,7 +94,6 @@ class _VirtualMachine(object):
     __slots__ = (
         "_unused_cores",
         "_unused_links",
-        "_n_cpus_per_chip",
         "_n_router_entries_per_router",
         "_machine",
         "_sdram_per_chip",
@@ -118,8 +114,6 @@ class _VirtualMachine(object):
             router_entries_per_chip=Router.ROUTER_DEFAULT_AVAILABLE_ENTRIES,
             validate=True):
 
-        if n_cpus_per_chip is None:
-            n_cpus_per_chip = Machine.max_cores_per_chip()
         self._n_router_entries_per_router = router_entries_per_chip
 
         _verify_width_height(width, height)
@@ -127,7 +121,6 @@ class _VirtualMachine(object):
 
         # Store the details
         self._sdram_per_chip = sdram_per_chip
-        self._n_cpus_per_chip = n_cpus_per_chip
 
         # Store the down items
         unused_chips = []
@@ -173,19 +166,26 @@ class _VirtualMachine(object):
         # If there are no wrap arounds, and the the size is not 2 * 2,
         # the possible chips depend on the 48 chip board's gaps
         configured_chips = dict()
-        for (eth_x, eth_y) in ethernet_chips:
-            for x_y in self._machine.get_xys_by_ethernet(eth_x, eth_y):
-                if x_y not in unused_chips:
-                    configured_chips[x_y] = (eth_x, eth_y)
+        if n_cpus_per_chip is None:
+            for (eth_x, eth_y) in ethernet_chips:
+                for (x_y, n_cores) in self._machine.get_xy_cores_by_ethernet(
+                        eth_x, eth_y):
+                   if x_y not in unused_chips:
+                       configured_chips[x_y] = (eth_x, eth_y, n_cores)
+        else:
+            for (eth_x, eth_y) in ethernet_chips:
+                for x_y in self._machine.get_xys_by_ethernet(eth_x, eth_y):
+                    if x_y not in unused_chips:
+                        configured_chips[x_y] = (eth_x, eth_y, n_cpus_per_chip)
 
         # for chip in self._unreachable_outgoing_chips:
         #    configured_chips.remove(chip)
         # for chip in self._unreachable_incoming_chips:
         #    configured_chips.remove(chip)
 
-        for xy in configured_chips:
-            x, y = xy
-            if configured_chips[xy] == xy:
+        for x_y in configured_chips:
+            x, y = x_y
+            if x_y in ethernet_chips:
                 new_chip = self._create_chip(
                     x, y, configured_chips, "127.0.{}.{}".format(x, y))
             else:
@@ -211,11 +211,11 @@ class _VirtualMachine(object):
         else:
             sdram = SDRAM(self._sdram_per_chip)
 
-        (eth_x, eth_y) = configured_chips[(x, y)]
+        (eth_x, eth_y, n_cores) = configured_chips[(x, y)]
 
         down_cores = self._unused_cores.get((x, y), None)
         return Chip(
-            x, y, self._n_cpus_per_chip, chip_router, sdram, eth_x, eth_y,
+            x, y, n_cores, chip_router, sdram, eth_x, eth_y,
             ip_address, down_cores=down_cores)
 
     def _calculate_links(self, x, y, configured_chips):

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 import logging
 from .chip import Chip
 from .exceptions import SpinnMachineInvalidParameterException
-from .machine import Machine
 from .router import Router
 from .sdram import SDRAM
 from .link import Link
@@ -170,8 +169,8 @@ class _VirtualMachine(object):
             for (eth_x, eth_y) in ethernet_chips:
                 for (x_y, n_cores) in self._machine.get_xy_cores_by_ethernet(
                         eth_x, eth_y):
-                   if x_y not in unused_chips:
-                       configured_chips[x_y] = (eth_x, eth_y, n_cores)
+                    if x_y not in unused_chips:
+                        configured_chips[x_y] = (eth_x, eth_y, n_cores)
         else:
             for (eth_x, eth_y) in ethernet_chips:
                 for x_y in self._machine.get_xys_by_ethernet(eth_x, eth_y):

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from spinn_machine import Link, SDRAM, Router, Chip, virtual_machine, Machine, \
-    machine_from_size
+from spinn_machine import (Chip, Link, Machine, machine_from_size, Router,
+                           SDRAM, virtual_machine)
+
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException,
     SpinnMachineInvalidParameterException)
@@ -932,27 +933,21 @@ class TestVirtualMachine(unittest.TestCase):
 
     def test_n_cores_full_wrap(self):
         machine = virtual_machine(12, 12)
-        n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
             n_cores
             for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
-
-    def test_n_cores_full_wrap(self):
-        machine = virtual_machine(12, 12)
         n_cores = sum(chip.n_processors for chip in machine.chips)
-        n_cores = sum(
-            n_cores
-            for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
-        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
 
     def test_n_cores_no_wrap(self):
         machine = virtual_machine(16, 16)
-        n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
             n_cores
             for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
+        n_cores = sum(chip.n_processors for chip in machine.chips)
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
 
     def test_n_cores_horizontal_wrap(self):
         machine = virtual_machine(12, 16)
@@ -976,7 +971,7 @@ class TestVirtualMachine(unittest.TestCase):
             cores for (_, cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
         n_cores = sum(chip.n_processors for chip in machine.chips)
-        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD )
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
 
     def test_n_cores_2_2(self):
         machine = virtual_machine(2, 2)

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -935,7 +935,7 @@ class TestVirtualMachine(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
             n_cores
-            for (_, _, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
 
     def test_n_cores_full_wrap(self):
@@ -943,7 +943,7 @@ class TestVirtualMachine(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
             n_cores
-            for (_, _, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
 
     def test_n_cores_no_wrap(self):
@@ -951,43 +951,48 @@ class TestVirtualMachine(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
             n_cores
-            for (_, _, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
 
     def test_n_cores_horizontal_wrap(self):
         machine = virtual_machine(12, 16)
-        n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
             n_cores
-            for (_, _, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            for (_, n_cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
+        n_cores = sum(chip.n_processors for chip in machine.chips)
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
 
     def test_n_cores_vertical_wrap(self):
         machine = virtual_machine(12, 16)
         n_cores = sum(chip.n_processors for chip in machine.chips)
-        n_cores = sum(
-            cores for (_, _, cores) in machine.get_xy_cores_by_ethernet(0, 0))
-        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
+        n_cores = sum(chip.n_processors for chip in machine.chips)
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
 
     def test_n_cores_8_8(self):
         machine = virtual_machine(8, 8)
-        n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
-            cores for (_, _, cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            cores for (_, cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
+        n_cores = sum(chip.n_processors for chip in machine.chips)
+        self.assertEquals(n_cores, self.TYPICAL_N_CORES_PER_BOARD )
 
     def test_n_cores_2_2(self):
         machine = virtual_machine(2, 2)
-        n_cores = sum(chip.n_processors for chip in machine.chips)
         n_cores = sum(
-            cores for (_, _, cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            cores for (_, cores) in machine.get_xy_cores_by_ethernet(0, 0))
+        self.assertEquals(n_cores, 4 * 18)
+        n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEquals(n_cores, 4 * 18)
 
     def test_n_cores_weird(self):
+        # Can not do a weird VirtualMachine so use an empty one
         machine = machine_from_size(5, 5)
         n_cores = sum(
-            cores for (_, _, cores) in machine.get_xy_cores_by_ethernet(0, 0))
+            cores for (_, cores) in machine.get_xy_cores_by_ethernet(0, 0))
         self.assertEquals(n_cores, 5 * 5 * 18)
+        # Machine is empty so can not do sum of actual processors
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If a virtual machine is requested WITHOUT specifying n_cpus_per_chip  (or passing in None) a Machine is created with a split between 18 and 17 core chips as is typical in the 1,000,000 core machine.

Builds on: https://github.com/SpiNNakerManchester/SpiNNMachine/pull/124
So must be done AFTER that PR group.

Currently no matching PR to get the MaxMachineGenerators to use this but there probably should be one.