### PR TITLE
Upgrade travis dist to bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
   - 2.7
   - 3.6
   - 3.7
-dist: bionic
+dist: focal
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
   - 2.7
   - 3.6
   - 3.7
-dist: xenial
+dist: bionic
 addons:
   apt:
     packages:

--- a/unittests/test_router.py
+++ b/unittests/test_router.py
@@ -33,8 +33,8 @@ class TestingRouter(unittest.TestCase):
             self.assertTrue(i in r)
             self.assertEqual(r.get_link(i), links[i])
             self.assertEqual(r[i], links[i])
-        self.assertEqual([l[0] for l in r], [0, 1, 2, 3])
-        self.assertEqual([l[1].source_link_id for l in r], [0, 1, 2, 3])
+        self.assertEqual([link[0] for link in r], [0, 1, 2, 3])
+        self.assertEqual([link[1].source_link_id for link in r], [0, 1, 2, 3])
 
         self.assertFalse(r.emergency_routing_enabled)
         self.assertEqual(r.n_available_multicast_entries, 1024)


### PR DESCRIPTION
Upgrading Travis Ubuntu distribution to 18.04 (bionic) to help us with binaries that are close to the ITCM limit.

See https://github.com/orgs/SpiNNakerManchester/projects/32 for full list of PRs.