### PR TITLE
Add link to info

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -37,13 +37,13 @@ class Chip(object):
     __slots__ = (
         "_x", "_y", "_p", "_router", "_sdram", "_ip_address", "_virtual",
         "_tag_ids", "_nearest_ethernet_x", "_nearest_ethernet_y",
-        "_n_user_processors"
+        "_n_user_processors", "_parent_link"
     )
 
     # pylint: disable=too-many-arguments
     def __init__(self, x, y, n_processors, router, sdram, nearest_ethernet_x,
-                 nearest_ethernet_y, ip_address=None, virtual=False,
-                 tag_ids=None, down_cores=None):
+                 nearest_ethernet_y, parent_link, ip_address=None,
+                 virtual=False, tag_ids=None, down_cores=None):
         """
         :param x: the x-coordinate of the chip's position in the\
             two-dimensional grid of chips
@@ -71,6 +71,9 @@ class Chip(object):
         :type nearest_ethernet_x: int or None
         :param nearest_ethernet_y: the nearest Ethernet y coordinate
         :type nearest_ethernet_y: int or None
+        :param parent_link: The link down which the parent chips is found in
+            the tree of chips towards the root (boot) chip
+        :type parent_link: int or None
         :param down_cores: Ids of cores that are down for this Chip
         :type down_cores: collection of int
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
@@ -92,6 +95,7 @@ class Chip(object):
         self._virtual = virtual
         self._nearest_ethernet_x = nearest_ethernet_x
         self._nearest_ethernet_y = nearest_ethernet_y
+        self._parent_link = parent_link
 
     def __generate_processors(self, n_processors, down_cores):
         global standard_processors
@@ -269,6 +273,16 @@ class Chip(object):
             if not processor.is_monitor:
                 return processor
         return None
+
+    @property
+    def parent_link(self):
+        """ The link down which the parent is found in the tree of chips rooted
+            at the machine root chip (probably 0, 0 in most cases).  This will
+            be None if the chip information didn't contain this value.
+
+        :rtype: int or None
+        """
+        return self._parent_link
 
     def __iter__(self):
         """ Get an iterable of processor identifiers and processors

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -42,8 +42,8 @@ class Chip(object):
 
     # pylint: disable=too-many-arguments
     def __init__(self, x, y, n_processors, router, sdram, nearest_ethernet_x,
-                 nearest_ethernet_y, parent_link=None, ip_address=None,
-                 virtual=False, tag_ids=None, down_cores=None):
+                 nearest_ethernet_y, ip_address=None, virtual=False,
+                 tag_ids=None, down_cores=None, parent_link=None):
         """
         :param x: the x-coordinate of the chip's position in the\
             two-dimensional grid of chips
@@ -71,11 +71,11 @@ class Chip(object):
         :type nearest_ethernet_x: int or None
         :param nearest_ethernet_y: the nearest Ethernet y coordinate
         :type nearest_ethernet_y: int or None
+        :param down_cores: Ids of cores that are down for this Chip
+        :type down_cores: collection of int
         :param parent_link: The link down which the parent chips is found in
             the tree of chips towards the root (boot) chip
         :type parent_link: int or None
-        :param down_cores: Ids of cores that are down for this Chip
-        :type down_cores: collection of int
         :raise spinn_machine.exceptions.SpinnMachineAlreadyExistsException: \
             If processors contains any two processors with the same\
             processor_id

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -42,7 +42,7 @@ class Chip(object):
 
     # pylint: disable=too-many-arguments
     def __init__(self, x, y, n_processors, router, sdram, nearest_ethernet_x,
-                 nearest_ethernet_y, parent_link, ip_address=None,
+                 nearest_ethernet_y, parent_link=None, ip_address=None,
                  virtual=False, tag_ids=None, down_cores=None):
         """
         :param x: the x-coordinate of the chip's position in the\

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -44,8 +44,8 @@ ONE_LINK_DEAD_CHIP = (
     "address {} but as chip {}:{} is dead, we cannot report its ip address. "
     "Please report this to spinnakerusers@googlegroups.com \n\n")
 CHIP_REMOVED_BY_DEAD_PARENT = (
-    "The chip {}:{} will fail to receive signals because it's parent {}:{} in"
-    " the signal tree has dissapeared from the machine since it was booted."
+    "The chip {}:{} will fail to receive signals because its parent {}:{} in"
+    " the signal tree has disappeared from the machine since it was booted."
     " Please report this to spinnakerusers@googlegroups.com \n\n")
 
 

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -272,7 +272,7 @@ def machine_repair(original, repair_machine=False, removed_chips=tuple()):
                 msg = CHIP_REMOVED_BY_DEAD_PARENT.format(
                     chip.x, chip.y, parent_x, parent_y)
                 if repair_machine:
-                    dead_chips.add((parent_x, parent_y))
+                    dead_chips.add((chip.x, chip.y))
                     logger.warning(msg)
                 else:
                     logger.error(msg)

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -43,6 +43,10 @@ ONE_LINK_DEAD_CHIP = (
     "exist, but the opposite does. chip {}:{} resides on board with ip "
     "address {} but as chip {}:{} is dead, we cannot report its ip address. "
     "Please report this to spinnakerusers@googlegroups.com \n\n")
+CHIP_REMOVED_BY_DEAD_PARENT = (
+    "The chip {}:{} will fail to receive signals because it's parent {}:{} in"
+    " the signal tree has dissapeared from the machine since it was booted."
+    " Please report this to spinnakerusers@googlegroups.com \n\n")
 
 
 def machine_from_size(width, height, chips=None, origin=None):
@@ -259,6 +263,20 @@ def machine_repair(original, repair_machine=False, removed_chips=tuple()):
             else:
                 logger.error(uni_direction_link_message)
                 error_message += uni_direction_link_message
+
+    for chip in original.chips:
+        if chip.parent_link is not None:
+            parent_x, parent_y = original.xy_over_link(
+                chip.x, chip.y, chip.parent_link)
+            if not original.is_chip_at(parent_x, parent_y):
+                msg = CHIP_REMOVED_BY_DEAD_PARENT.format(
+                    chip.x, chip.y, parent_x, parent_y)
+                if repair_machine:
+                    dead_chips.add((parent_x, parent_y))
+                    logger.warning(msg)
+                else:
+                    logger.error(msg)
+                    error_message += msg
 
     if not repair_machine and error_message != "":
         raise SpinnMachineException(error_message)


### PR DESCRIPTION
Adds the concept of a "parent link" where this is the link to the parent chip in the tree used to send signals, which is rooted at the machine root chip.  This concept is then used (when present) to remove additional chips when a chip stops responding after boot.

Depends on SpiNNakerManchester/spinnaker_tools#135