### PR TITLE
Fix the Python documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,7 +49,15 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx'
 ]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3.6', None),
+    'numpy': ("https://numpy.org/doc/stable/", None),
+    'spinn_utilities': (
+        'https://spinnutils.readthedocs.io/en/latest/', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -65,7 +73,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'SpiNNMachine'
-copyright = u'2014-2017'
+copyright = u'2014-2020'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -359,5 +367,6 @@ for f in os.listdir("."):
         os.remove(f)
 apidoc.main([None, '-o', ".", "../../spinn_machine",
              # Exclusions...
-             "../../spinn_machine/[a-df-ikm-su-z]*.py",
+             "../../spinn_machine/[a-df-hkm-su-z]*.py",
+             "../../spinn_machine/ignores/i*.py",
              "../../spinn_machine/link.py"])

--- a/spinn_machine/ignores/ignore_chip.py
+++ b/spinn_machine/ignores/ignore_chip.py
@@ -15,41 +15,54 @@
 
 
 class IgnoreChip(object):
+    """ Represents a chip to be ignored when building a machine. This is \
+        typically because it has a fault in the SpiNNaker router.
+    """
 
     __slots__ = ["x", "y", "ip_address"]
 
     def __init__(self, x, y, ip_address=None):
         """
-
-        :param x: X coorridate of a Chip to ignore
+        :param x: X coordinate of a Chip to ignore
         :type x: int or str
-        :param y: Y coorridate of a Chip to ignore
+        :param y: Y coordinate of a Chip to ignore
         :type y: int or str
-        :param ip_address: Optional ip_address which if provided make\
+        :param ip_address: Optional IP address which, if provided, make
             x and y local coordinates
         :type ip_address: str or None
         """
+        #: X coordinate of the chip to ignore
         self.x = int(x)
+        #: Y coordinate of the chip to ignore
         self.y = int(y)
+        #: IP address of the board with the chip; if not ``None``, the
+        #: coordinates are local to that board
         self.ip_address = ip_address
 
     @staticmethod
     def parse_single_string(downed_chip):
-        """
-        Converts a Sting into an IgnoreChip object
+        """ Converts a string into an :py:class:`IgnoreChip` object
 
-        format is:
+        The supported format is::
+
             <down_chip_id> = <chip_x>,<chip_y>[,<ip>]
-        where:
-            <chip_x> is the x-coordinate of a down chip
-            <chip_x> is the y-coordinate of a down chip
-            <ip> is an OPTIONAL ip address in the 127.0.0.0 format.
-        If provided the <chip_x> <chip_y> will be considered local to the\
-            board with this ip address
 
-        :param downed_chip: String representation of one chip to ignore
-        :type downed_chip: str
+        where:
+
+        * ``<chip_x>`` is the x-coordinate of a down chip
+        * ``<chip_x>`` is the y-coordinate of a down chip
+        * ``<ip>`` is an *optional* IP address in the ``127.0.0.0`` format.
+          If provided, the ``<chip_x>,<chip_y>`` will be considered local to
+          the board with this IP address.
+
+        Two examples::
+
+            4,7
+            6,5,10.11.12.13
+
+        :param str downed_chip: representation of one chip to ignore
         :return: An IgnoreChip Object
+        :rtype: IgnoreChip
         """
         parts = downed_chip.split(",")
 
@@ -63,24 +76,31 @@ class IgnoreChip(object):
 
     @staticmethod
     def parse_string(downed_chips):
-        """
-        Converts a Sting into a (possibly empty) set of IgnoreChip objects
+        """ Converts a string into a (possibly empty) set of \
+            :py:class:`IgnoreChip` objects
 
-        format is:
+        format is::
+
             down_chips = <down_chip_id>[:<down_chip_id]*
             <down_chip_id> = <chip_x>,<chip_y>[,<ip>]
+
         where:
-            <chip_x> is the x-coordinate of a down chip
-            <chip_x> is the y-coordinate of a down chip
-            <ip> is an OPTIONAL ip address in the 127.0.0.0 format.
-        If provided the <chip_x> <chip_y> will be considered local to the\
-        board with this ip address
 
-        The string None (case insentitive) is used to represent no ignores
+        * ``<chip_x>`` is the x-coordinate of a down chip
+        * ``<chip_y>`` is the y-coordinate of a down chip
+        * ``<ip>`` is an *optional** IP address in the ``127.0.0.0`` format.
+          If provided, the ``<chip_x>,<chip_y>`` will be considered local to
+          the board with this IP address.
 
-        :param downed_chips: String representation of zero or chips to ignore
-        :type downed_chips: str
-        :return:  Set (possibly empty) of IgnoreChips
+        The string ``None`` (case-insensitive) is used to represent no ignores
+
+        An example::
+
+            4,7:6,5,10.11.12.13
+
+        :param str downed_chips: representation of zero or chips to ignore
+        :return: Set (possibly empty) of IgnoreChips
+        :rtype: set(IgnoreChip)
         """
         ignored_chips = set()
         if downed_chips is None:

--- a/spinn_machine/ignores/ignore_core.py
+++ b/spinn_machine/ignores/ignore_core.py
@@ -50,7 +50,7 @@ class IgnoreCore(object):
 
     @property
     def virtual_p(self):
-        """ Get the virtual processor ID.
+        """ The virtual processor ID.
 
         When the processor is given as a physical processor, this is converted
         to a virtual core ID using the typical virtual/physical core map;

--- a/spinn_machine/ignores/ignore_link.py
+++ b/spinn_machine/ignores/ignore_link.py
@@ -15,46 +15,53 @@
 
 
 class IgnoreLink(object):
+    """ Represents a link that should be ignored when building a machine.
+    """
 
     __slots__ = ["x", "y", "link", "ip_address"]
 
     def __init__(self, x, y, link, ip_address=None):
         """
-
-        :param x: X coorridate of a Chip to ignore
+        :param x: X coordinate of a chip with a link to ignore
         :type x: int or str
-        :param y: Y coorridate of a Chip to ignore
-        :type y: int os str
-        :param link: id of the link to ignore
+        :param y: Y coorridate of a chip with a link to ignore
+        :type y: int or str
+        :param link: ID of the link to ignore
         :type link: int or str
-        :param ip_address: Optional ip_address which if provided make\
-            x and y local coordinates
+        :param ip_address: Optional IP address which, if provided, makes
+            x and y be local coordinates
         :type ip_address: str or None
         """
+        #: X coordinate of the chip with the link to ignore
         self.x = int(x)
+        #: Y coordinate of the chip with the link to ignore
         self.y = int(y)
+        #: Link ID to ignore
         self.link = int(link)
+        #: IP address of the board with the chip; if not ``None``, the
+        #: coordinates are local to that board
         self.ip_address = ip_address
 
     @staticmethod
     def parse_single_string(downed_core):
-        """
-        Converts a Sting into an IgnoreChip object
+        """ Converts a string into an :py:class:`IgnoreLink` object
 
-        format is:
-            <down_core> = <chip_x>,<chip_y>,<core_id>[,<ip>]
+        The format is::
+
+            <down_link> = <chip_x>,<chip_y>,<link_id>[,<ip>]
+
         where:
-            <chip_x> is the x-coordinate of a down chip
-            <chip_x> is the y-coordinate of a down chip
-            <core_id> is the virtual core ID of a core if > 0
-            or the phsical core if <= 0
-            <ip> is an OPTIONAL ip address in the 127.0.0.0 format.
-        If provided the <chip_x> <chip_y> will be considered local to the\
-            board with this ip address
 
-        :param downed_core: String representation of one chip to ignore
-        :type downed_core: str
-        :return: An IgnoreChip Object
+        * ``<chip_x>`` is the x-coordinate of a down chip
+        * ``<chip_x>`` is the y-coordinate of a down chip
+        * ``<link_id>`` is the link ID
+        * ``<ip>`` is an *optional* IP address in the ``127.0.0.0`` format.
+          If provided, the ``<chip_x>,<chip_y>`` will be considered local to
+          the board with this IP address.
+
+        :param str downed_core: representation of one link to ignore
+        :return: An IgnoreLink object
+        :rtype: IgnoreLink
         """
         parts = downed_core.split(",")
 
@@ -67,33 +74,35 @@ class IgnoreLink(object):
                 "Unexpected downed_core: {}".format(downed_core))
 
     @staticmethod
-    def parse_string(downed_cores):
-        """
-        Converts a Sting into a (possibly empty) set of IgnoreChip objects
+    def parse_string(downed_links):
+        """ Converts a string into a (possibly empty) set of \
+            :py:class:`IgnoreLink` objects
 
-        format is:
-            down_cores = <down_core_id>[:<down_core_id]*
-            <down_core_id> = <chip_x>,<chip_y>[,<ip>]
+        The format is::
+
+            down_links = <down_link_id>[:<down_link_id]*
+            <down_link_id> = <chip_x>,<chip_y>,<link_id>[,<ip>]
+
         where:
-            <chip_x> is the x-coordinate of a down chip
-            <chip_x> is the y-coordinate of a down chip
-            <core_id> is the virtual core ID of a core if > 0
-            or the phsical core if <= 0
-            <ip> is an OPTIONAL ip address in the 127.0.0.0 format.
-        If provided the <chip_x> <chip_y> will be considered local to the\
-            board with this ip address
 
-        The string None (case insentitive) is used to represent no ignores
+        * ``<chip_x>`` is the x-coordinate of a down chip
+        * ``<chip_x>`` is the y-coordinate of a down chip
+        * ``<link_id>`` is the link ID
+        * ``<ip>`` is an *optional* IP address in the ``127.0.0.0`` format.
+          If provided, the ``<chip_x>,<chip_y>`` will be considered local to
+          the board with this IP address
 
-        :param downed_cores: String representation of zero or chips to ignore
-        :type downed_cores: str
-        :return:  Set (possibly empty) of IgnoreChips
+        The string ``None`` (case insensitive) is used to represent no ignores
+
+        :param str downed_cores: representation of zero or chips to ignore
+        :return: Set (possibly empty) of IgnoreLinks
+        :rtype: set(IgnoreLink)
         """
         ignored_links = set()
-        if downed_cores is None:
+        if downed_links is None:
             return ignored_links
-        if downed_cores.lower() == "none":
+        if downed_links.lower() == "none":
             return ignored_links
-        for downed_chip in downed_cores.split(":"):
+        for downed_chip in downed_links.split(":"):
             ignored_links.add(IgnoreLink.parse_single_string(downed_chip))
         return ignored_links


### PR DESCRIPTION
These are the fixes to the documentation needed for SpiNNMachine to allow documentation to build without errors; these fixes are concentrated in the `spinn_machine.ignore` package. It also does some other basic fixes so that we don't have so many cut-n-paste jobs, and puts documentation on things where it was missing.