### PR TITLE
MulticastRoutingEntry.__hash.__

### DIFF
--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -191,6 +191,10 @@ class MulticastRoutingEntry(object):
             return False
         return (self._defaultable == other_entry.defaultable)
 
+    def __hash__(self):
+        return  self.routing_entry_key * 13 + self.mask * 19 + \
+                self._spinnaker_route * 29 * int(self._defaultable) * 131
+
     def __ne__(self, other):
         return not self.__eq__(other)
 

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -192,8 +192,8 @@ class MulticastRoutingEntry(object):
         return (self._defaultable == other_entry.defaultable)
 
     def __hash__(self):
-        return  self.routing_entry_key * 13 + self.mask * 19 + \
-                self._spinnaker_route * 29 * int(self._defaultable) * 131
+        return self.routing_entry_key * 13 + self.mask * 19 + \
+               self._spinnaker_route * 29 * int(self._defaultable) * 131
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -192,8 +192,8 @@ class MulticastRoutingEntry(object):
         return (self._defaultable == other_entry.defaultable)
 
     def __hash__(self):
-        return self.routing_entry_key * 13 + self.mask * 19 + \
-               self._spinnaker_route * 29 * int(self._defaultable) * 131
+        return (self.routing_entry_key * 13 + self.mask * 19 +
+                self._spinnaker_route * 29 * int(self._defaultable) * 131)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/unittests/test_multicast_routing_entry.py
+++ b/unittests/test_multicast_routing_entry.py
@@ -44,6 +44,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(
             a_multicast,
             pickle.loads(pickle.dumps(a_multicast, pickle.HIGHEST_PROTOCOL)))
+        hash(a_multicast)
 
     def test_duplicate_processors_ids(self):
         link_ids = list()


### PR DESCRIPTION
Added a hash method to MulticastRoutingEntry so they could be added to sets.

Note: While in the end not used by HostBasedBitFieldRouterCompressor PR still a nice to have.