### PR TITLE
It really helps a lot if you USE THE RIGHT URL

### DIFF
--- a/doc/doc_requirements.txt
+++ b/doc/doc_requirements.txt
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
--e git+https://github.com/SpiNNakerManchester/SpiNNUtils.git@master#egg=spinn_utilities
+-e git+https://github.com/SpiNNakerManchester/SpiNNUtils.git@master#egg=SpiNNUtilities


### PR DESCRIPTION
The egg name fragment was wrong; it didn't match what SpiNNUtil's `setup.py` declared its name to be. This was making readthedocs fail.