### PR TITLE
by_ethernet now excludes virtual chips

### DIFF
--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -60,19 +60,12 @@ class FullWrapMachine(Machine):
 
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        if self._virtual_chips:
-            for (x, y) in self._local_xys:
-                chip_xy = ((x + ethernet_x) % self._width,
-                           (y + ethernet_y) % self._height)
-                if chip_xy in self._chips and \
-                        chip_xy not in self._virtual_chips:
-                    yield chip_xy
-        else:
-            for (x, y) in self._local_xys:
-                chip_xy = ((x + ethernet_x) % self._width,
-                           (y + ethernet_y) % self._height)
-                if (chip_xy) in self._chips:
-                    yield chip_xy
+        for (x, y) in self._local_xys:
+            chip_xy = ((x + ethernet_x) % self._width,
+                       (y + ethernet_y) % self._height)
+            if chip_xy in self._chips and\
+                    chip_xy not in self._virtual_chips:
+                yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -58,21 +58,21 @@ class FullWrapMachine(Machine):
                 yield(((x + ethernet_x) % self._width,
                       (y + ethernet_y) % self._height), n_cores)
 
-    @overrides(Machine.get_chips_by_ethernet)
-    def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = ((x + ethernet_x) % self._width,
-                       (y + ethernet_y) % self._height)
-            if (chip_xy) in self._chips:
-                yield self._chips[chip_xy]
-
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = ((x + ethernet_x) % self._width,
-                       (y + ethernet_y) % self._height)
-            if (chip_xy) in self._chips:
-                yield chip_xy
+        if self._virtual_chips:
+            for (x, y) in self._local_xys:
+                chip_xy = ((x + ethernet_x) % self._width,
+                           (y + ethernet_y) % self._height)
+                if chip_xy in self._chips and \
+                        chip_xy not in self._virtual_chips:
+                    yield chip_xy
+        else:
+            for (x, y) in self._local_xys:
+                chip_xy = ((x + ethernet_x) % self._width,
+                           (y + ethernet_y) % self._height)
+                if (chip_xy) in self._chips:
+                    yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -52,19 +52,12 @@ class HorizontalWrapMachine(Machine):
 
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        if self._virtual_chips:
-            for (x, y) in self._local_xys:
-                chip_xy = ((x + ethernet_x) % self._width,
-                           (y + ethernet_y))
-                if chip_xy in self._chips and \
-                        chip_xy not in self._virtual_chips:
-                    yield chip_xy
-        else:
-            for (x, y) in self._local_xys:
-                chip_xy = ((x + ethernet_x) % self._width,
-                           (y + ethernet_y))
-                if chip_xy in self._chips:
-                    yield chip_xy
+         for (x, y) in self._local_xys:
+            chip_xy = ((x + ethernet_x) % self._width,
+                       (y + ethernet_y))
+            if chip_xy in self._chips and \
+                    chip_xy not in self._virtual_chips:
+                yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -52,7 +52,7 @@ class HorizontalWrapMachine(Machine):
 
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-         for (x, y) in self._local_xys:
+        for (x, y) in self._local_xys:
             chip_xy = ((x + ethernet_x) % self._width,
                        (y + ethernet_y))
             if chip_xy in self._chips and \

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -50,21 +50,21 @@ class HorizontalWrapMachine(Machine):
         for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
             yield(((x + ethernet_x) % self._width, (y + ethernet_y)), n_cores)
 
-    @overrides(Machine.get_chips_by_ethernet)
-    def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = ((x + ethernet_x) % self._width,
-                       (y + ethernet_y))
-            if (chip_xy) in self._chips:
-                yield self._chips[chip_xy]
-
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = ((x + ethernet_x) % self._width,
-                       (y + ethernet_y))
-            if (chip_xy) in self._chips:
-                yield chip_xy
+        if self._virtual_chips:
+            for (x, y) in self._local_xys:
+                chip_xy = ((x + ethernet_x) % self._width,
+                           (y + ethernet_y))
+                if chip_xy in self._chips and \
+                        chip_xy not in self._virtual_chips:
+                    yield chip_xy
+        else:
+            for (x, y) in self._local_xys:
+                chip_xy = ((x + ethernet_x) % self._width,
+                           (y + ethernet_y))
+                if chip_xy in self._chips:
+                    yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -146,7 +146,7 @@ def _find_virtual_links(machine):
     :return: Map of Chip to list of virtual links
     """
     virtual_links_dict = defaultdict(list)
-    for chip in machine._virtual_chips:
+    for chip in machine.virtual_chips:
         # assume all links need special treatment
         for link in chip.router.links:
             virtual_links_dict[chip].append(link)

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -179,7 +179,7 @@ class Machine(object, metaclass=AbstractBase):
         if chips is not None:
             self.add_chips(chips)
 
-        self._virtual_chips = list()
+        self._virtual_chips = OrderedDict()
 
         if origin is None:
             self._origin = ""
@@ -276,7 +276,6 @@ class Machine(object, metaclass=AbstractBase):
         :rtype: iterable(tuple(int,int))
         """
 
-    @abstractmethod
     def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
         """
         Yields the actual chips on the board with this ethernet.
@@ -293,6 +292,9 @@ class Machine(object, metaclass=AbstractBase):
         :return: Yields the chips on this board.
         :rtype: iterable(Chip)
         """
+        for chip_xy in self.get_existing_xys_by_ethernet(
+                ethernet_x, ethernet_y):
+            yield self._chips[chip_xy]
 
     @abstractmethod
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
@@ -559,7 +561,7 @@ class Machine(object, metaclass=AbstractBase):
         """
         :param ~spinn_machine.Chip chip: The virtual chip to add
         """
-        self._virtual_chips.append(chip)
+        self._virtual_chips[(chip.x, chip.y)] = chip
         self.add_chip(chip)
 
     def add_chips(self, chips):
@@ -1122,7 +1124,7 @@ class Machine(object, metaclass=AbstractBase):
         """
         :rtype: iterable(Chip)
         """
-        return self._virtual_chips
+        return self._virtual_chips.values()
 
     @property
     def local_xys(self):

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -56,19 +56,19 @@ class NoWrapMachine(Machine):
             for (x, y) in self._local_xys:
                 yield((x, y), n_cores)
 
-    @overrides(Machine.get_chips_by_ethernet)
-    def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = (x + ethernet_x, y + ethernet_y)
-            if (chip_xy) in self._chips:
-                yield self._chips[chip_xy]
-
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = (x + ethernet_x, y + ethernet_y)
-            if (chip_xy) in self._chips:
-                yield chip_xy
+        if self._virtual_chips:
+            for (x, y) in self._local_xys:
+                chip_xy = (x + ethernet_x, y + ethernet_y)
+                if chip_xy in self._chips and \
+                        chip_xy not in self._virtual_chips:
+                    yield chip_xy
+        else:
+            for (x, y) in self._local_xys:
+                chip_xy = (x + ethernet_x, y + ethernet_y)
+                if chip_xy in self._chips:
+                    yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -58,17 +58,11 @@ class NoWrapMachine(Machine):
 
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        if self._virtual_chips:
-            for (x, y) in self._local_xys:
-                chip_xy = (x + ethernet_x, y + ethernet_y)
-                if chip_xy in self._chips and \
-                        chip_xy not in self._virtual_chips:
-                    yield chip_xy
-        else:
-            for (x, y) in self._local_xys:
-                chip_xy = (x + ethernet_x, y + ethernet_y)
-                if chip_xy in self._chips:
-                    yield chip_xy
+        for (x, y) in self._local_xys:
+            chip_xy = (x + ethernet_x, y + ethernet_y)
+            if chip_xy in self._chips and \
+                    chip_xy not in self._virtual_chips:
+                yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -50,21 +50,21 @@ class VerticalWrapMachine(Machine):
         for (x, y), n_cores in self.CHIPS_PER_BOARD.items():
             yield(((x + ethernet_x), (y + ethernet_y) % self._height), n_cores)
 
-    @overrides(Machine.get_chips_by_ethernet)
-    def get_chips_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = ((x + ethernet_x),
-                       (y + ethernet_y) % self._height)
-            if (chip_xy) in self._chips:
-                yield self._chips[chip_xy]
-
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        for (x, y) in self._local_xys:
-            chip_xy = ((x + ethernet_x),
-                       (y + ethernet_y) % self._height)
-            if (chip_xy) in self._chips:
-                yield chip_xy
+        if self._virtual_chips:
+            for (x, y) in self._local_xys:
+                chip_xy = ((x + ethernet_x),
+                           (y + ethernet_y) % self._height)
+                if chip_xy in self._chips and \
+                        chip_xy not in self._virtual_chips:
+                    yield chip_xy
+        else:
+            for (x, y) in self._local_xys:
+                chip_xy = ((x + ethernet_x),
+                           (y + ethernet_y) % self._height)
+                if chip_xy in self._chips:
+                    yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -52,19 +52,12 @@ class VerticalWrapMachine(Machine):
 
     @overrides(Machine.get_existing_xys_by_ethernet)
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
-        if self._virtual_chips:
-            for (x, y) in self._local_xys:
-                chip_xy = ((x + ethernet_x),
-                           (y + ethernet_y) % self._height)
-                if chip_xy in self._chips and \
-                        chip_xy not in self._virtual_chips:
-                    yield chip_xy
-        else:
-            for (x, y) in self._local_xys:
-                chip_xy = ((x + ethernet_x),
-                           (y + ethernet_y) % self._height)
-                if chip_xy in self._chips:
-                    yield chip_xy
+        for (x, y) in self._local_xys:
+            chip_xy = ((x + ethernet_x),
+                       (y + ethernet_y) % self._height)
+            if chip_xy in self._chips and \
+                    chip_xy not in self._virtual_chips:
+                yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)
     def get_down_xys_by_ethernet(self, ethernet_x, ethernet_y):


### PR DESCRIPTION
machine._virtual_chips turned into an OrderedDict to make ii cheaper to check is chip xy is virtual

JsonMachine changed to use the virtual_chips property rather than underscore param

get_existing_xys_by_ethernet updated to check against virtual_chips if needed

get_chips_by_ethernet changed to work based off get_existing_xys_by_ethernet
(only known non test use of get_chips_by_ethernet should be using get_existing_xys_by_etherne anyway.