### PR TITLE
Router max entries is 1023

### DIFF
--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -61,6 +61,7 @@ class Machine(object, metaclass=AbstractBase):
         (6, 7): 18, (7, 3): 18, (7, 4): 18, (7, 5): 18, (7, 6): 18, (7, 7): 18
     }
     BOARD_48_CHIPS = list(CHIPS_PER_BOARD.keys())
+    ROUTER_ENTRIES = 1023
 
     __slots__ = (
         "_boot_ethernet_address",

--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 from .exceptions import (
     SpinnMachineAlreadyExistsException, SpinnMachineInvalidParameterException)
+from .machine import Machine
 
 
 class Router(object):
@@ -26,8 +27,6 @@ class Router(object):
             * ``source_link_id`` is the ID of a link
             * ``link`` is the :py:class:`Link` with ID ``source_link_id``
     """
-
-    ROUTER_DEFAULT_AVAILABLE_ENTRIES = 1024
 
     # The maximum number of links/directions a router can handle
     MAX_LINKS_PER_ROUTER = 6
@@ -44,7 +43,7 @@ class Router(object):
 
     def __init__(
             self, links, emergency_routing_enabled=False,
-            n_available_multicast_entries=ROUTER_DEFAULT_AVAILABLE_ENTRIES):
+            n_available_multicast_entries=Machine.ROUTER_ENTRIES):
         """
         :param iterable(~spinn_machine.Link) links: iterable of links
         :param bool emergency_routing_enabled:

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -22,6 +22,7 @@ from .router import Router
 from .sdram import SDRAM
 from .link import Link
 from .spinnaker_triad_geometry import SpiNNakerTriadGeometry
+from .machine import Machine
 from .machine_factory import machine_from_size
 from spinn_machine.ignores import IgnoreChip, IgnoreCore, IgnoreLink
 
@@ -61,7 +62,7 @@ def virtual_machine(
         width, height, n_cpus_per_chip=None,
         sdram_per_chip=SDRAM.DEFAULT_SDRAM_BYTES,
         down_chips=None, down_cores=None, down_links=None,
-        router_entries_per_chip=Router.ROUTER_DEFAULT_AVAILABLE_ENTRIES,
+        router_entries_per_chip=Machine.ROUTER_ENTRIES,
         validate=True):
     """ Create a virtual SpiNNaker machine, used for planning execution.
 
@@ -107,7 +108,7 @@ class _VirtualMachine(object):
             self, width, height, n_cpus_per_chip=None,
             sdram_per_chip=SDRAM.DEFAULT_SDRAM_BYTES,
             down_chips=None, down_cores=None, down_links=None,
-            router_entries_per_chip=Router.ROUTER_DEFAULT_AVAILABLE_ENTRIES,
+            router_entries_per_chip=Machine.ROUTER_ENTRIES,
             validate=True):
 
         self._n_router_entries_per_router = router_entries_per_chip

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -62,7 +62,6 @@ def virtual_machine(
         width, height, n_cpus_per_chip=None,
         sdram_per_chip=SDRAM.DEFAULT_SDRAM_BYTES,
         down_chips=None, down_cores=None, down_links=None,
-        router_entries_per_chip=Machine.ROUTER_ENTRIES,
         validate=True):
     """ Create a virtual SpiNNaker machine, used for planning execution.
 
@@ -71,7 +70,6 @@ def virtual_machine(
     :param int n_cpus_per_chip: The number of CPUs to put on each chip
     :param sdram_per_chip: The amount of SDRAM to give to each chip
     :type sdram_per_chip: int or None
-    :param int router_entries_per_chip: the number of entries to each router
     :param bool validate: if True will call the machine validate function
     :returns: a virtual machine (that cannot execute code)
     :rtype: Machine
@@ -79,8 +77,7 @@ def virtual_machine(
 
     factory = _VirtualMachine(
         width, height, n_cpus_per_chip,  sdram_per_chip,
-        down_chips, down_cores, down_links,
-        router_entries_per_chip, validate)
+        down_chips, down_cores, down_links, validate)
     return factory.machine
 
 
@@ -91,7 +88,6 @@ class _VirtualMachine(object):
     __slots__ = (
         "_unused_cores",
         "_unused_links",
-        "_n_router_entries_per_router",
         "_machine",
         "_sdram_per_chip",
         "_with_monitors")
@@ -108,10 +104,7 @@ class _VirtualMachine(object):
             self, width, height, n_cpus_per_chip=None,
             sdram_per_chip=SDRAM.DEFAULT_SDRAM_BYTES,
             down_chips=None, down_cores=None, down_links=None,
-            router_entries_per_chip=Machine.ROUTER_ENTRIES,
             validate=True):
-
-        self._n_router_entries_per_router = router_entries_per_chip
 
         _verify_width_height(width, height)
         self._machine = machine_from_size(width, height, origin=self.ORIGIN)
@@ -201,8 +194,7 @@ class _VirtualMachine(object):
     def _create_chip(self, x, y, configured_chips, ip_address=None):
         chip_links = self._calculate_links(x, y, configured_chips)
         chip_router = Router(
-            chip_links,
-            n_available_multicast_entries=self._n_router_entries_per_router)
+            chip_links)
         if self._sdram_per_chip is None:
             sdram = SDRAM()
         else:

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -22,7 +22,6 @@ from .router import Router
 from .sdram import SDRAM
 from .link import Link
 from .spinnaker_triad_geometry import SpiNNakerTriadGeometry
-from .machine import Machine
 from .machine_factory import machine_from_size
 from spinn_machine.ignores import IgnoreChip, IgnoreCore, IgnoreLink
 


### PR DESCRIPTION
This fixes a number of issues.

1. ROUTER_DEFAULT_AVAILABLE_ENTRIES = 1024   Which is WRONG!
2. Constant was not in Machine with all the other ones that  will change for Spinnaker2
3. Currently used value comes from the cfg but it does not make sense to let the user change that

Must be done at the same tine a:
https://github.com/SpiNNakerManchester/PACMAN/pull/377
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/798
