### PR TITLE
Where is chip

### DIFF
--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -376,7 +376,7 @@ class Machine(object, metaclass=AbstractBase):
             chip.nearest_ethernet_x, chip.nearest_ethernet_y)
         (localx, localy) = self.get_local_xy(chip)
         return (f"global chip {chip.x}, {chip.y} on {chip00.ip_address} "
-                f"is chip {localx}, {local00.y} on {local00.ip_address}")
+                f"is chip {localx}, {localy} on {local00.ip_address}")
 
     def where_is_xy(self, x, y):
         """

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -361,6 +361,36 @@ class Machine(object, metaclass=AbstractBase):
         :rtype: tuple(int,int)
         """
 
+    def where_is_chip(self, chip):
+        """
+        Returns global and local location for this chip
+
+        This method assumes that chip is on the machine or is a copy of a
+        chip on the machine
+
+        :param Chip chip: A Chip in the machine
+        :rtype: str
+        """
+        chip00 = self.get_chip_at(0, 0)
+        local00 = self.get_chip_at(
+            chip.nearest_ethernet_x, chip.nearest_ethernet_y)
+        (localx, localy) = self.get_local_xy(chip)
+        return (f"global chip {chip.x}, {chip.y} on {chip00.ip_address} "
+                f"is chip {localx}, {local00.y} on {local00.ip_address}")
+
+    def where_is_xy(self, x, y):
+        """
+        Returns global and local location for this chip
+
+        :param int x:
+        :param int y:
+        :rtype: str
+        """
+        chip = self.get_chip_at(x, y)
+        if chip:
+            return self.where_is_chip(chip)
+        return f"No chip {x}, {y} found"
+
     @abstractmethod
     def get_global_xy(self, local_x, local_y, ethernet_x, ethernet_y):
         """

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -1021,6 +1021,20 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
+        chip11 = machine.get_chip_at(1, 1)
+        where = machine.where_is_chip(chip11)
+        self.assertEqual(
+            where, 'global chip 1, 1 on 127.0.0.0 is chip 1, 0 on 127.0.0.0')
+        chip1112 = machine.get_chip_at(11, 12)
+        where = machine.where_is_chip(chip1112)
+        self.assertEqual(
+            where, 'global chip 11, 12 on 127.0.0.0 is chip 7, 8 on 127.0.4.8')
+        where = machine.where_is_xy(10, 5)
+        self.assertEqual(
+            where, 'global chip 10, 5 on 127.0.0.0 is chip 2, 4 on 127.0.8.4')
+        where = machine.where_is_xy(15, 15)
+        self.assertEqual(where, 'No chip 15, 15 found')
+
 
     def test_n_cores_horizontal_wrap(self):
         machine = virtual_machine(12, 16)

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -1021,20 +1021,19 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(n_cores, self.TYPICAL_N_CORES_PER_BOARD)
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, self.TYPICAL_N_CORES_PER_BOARD * 3)
-        chip11 = machine.get_chip_at(1, 1)
-        where = machine.where_is_chip(chip11)
+        chip34 = machine.get_chip_at(3, 4)
+        where = machine.where_is_chip(chip34)
         self.assertEqual(
-            where, 'global chip 1, 1 on 127.0.0.0 is chip 1, 0 on 127.0.0.0')
+            where, 'global chip 3, 4 on 127.0.0.0 is chip 3, 4 on 127.0.0.0')
         chip1112 = machine.get_chip_at(11, 12)
         where = machine.where_is_chip(chip1112)
         self.assertEqual(
-            where, 'global chip 11, 12 on 127.0.0.0 is chip 7, 8 on 127.0.4.8')
+            where, 'global chip 11, 12 on 127.0.0.0 is chip 7, 4 on 127.0.4.8')
         where = machine.where_is_xy(10, 5)
         self.assertEqual(
-            where, 'global chip 10, 5 on 127.0.0.0 is chip 2, 4 on 127.0.8.4')
+            where, 'global chip 10, 5 on 127.0.0.0 is chip 2, 1 on 127.0.8.4')
         where = machine.where_is_xy(15, 15)
         self.assertEqual(where, 'No chip 15, 15 found')
-
 
     def test_n_cores_horizontal_wrap(self):
         machine = virtual_machine(12, 16)


### PR DESCRIPTION
Adds methods to machine to report the location of a chip.

Is used by other Prs But can be merged before them.

is tested by
