### PR TITLE
Reduce overhead

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -76,6 +76,8 @@ class Chip(object):
             If processors contains any two processors with the same
             ``processor_id``
         """
+        if virtual:
+            raise NotImplementedError("Unexpected use of virtual chip")
         self._x = x
         self._y = y
         self._p = self.__generate_processors(n_processors, down_cores)

--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -155,7 +155,7 @@ class FullWrapMachine(Machine):
     def concentric_xys(self, radius, start):
         # Aliases for convenience
         w, h = self._width, self._height
-        for (x, y) in self._basic_concentric_chips(radius, start):
+        for (x, y) in self._basic_concentric_xys(radius, start):
             yield (x % w, y % h)
 
     @property

--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -129,6 +129,7 @@ class FullWrapMachine(Machine):
         else:
             return length
 
+    @overrides(Machine.get_vector)
     def get_vector(self, source, destination):
         # Aliases for convenience
         w, h = self._width, self._height
@@ -165,6 +166,14 @@ class FullWrapMachine(Machine):
             return self._minimize_vector(x_down, y_left)
         else:
             return self._minimize_vector(dx, dy)
+
+    @overrides(Machine.concentric_chips)
+    def concentric_chips(self, radius, start):
+        # Aliases for convenience
+        w, h = self._width, self._height
+        sx, sy = start
+        for (x, y) in self._basic_concentric_chips(radius):
+            yield ((sx + x) % w, (sy + y) % h)
 
     @property
     @overrides(Machine.wrap)

--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -151,8 +151,8 @@ class FullWrapMachine(Machine):
         else:
             return self._minimize_vector(dx, dy)
 
-    @overrides(Machine.concentric_chips)
-    def concentric_chips(self, radius, start):
+    @overrides(Machine.concentric_xys)
+    def concentric_xys(self, radius, start):
         # Aliases for convenience
         w, h = self._width, self._height
         for (x, y) in self._basic_concentric_chips(radius, start):

--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -155,9 +155,8 @@ class FullWrapMachine(Machine):
     def concentric_chips(self, radius, start):
         # Aliases for convenience
         w, h = self._width, self._height
-        sx, sy = start
-        for (x, y) in self._basic_concentric_chips(radius):
-            yield ((sx + x) % w, (sy + y) % h)
+        for (x, y) in self._basic_concentric_chips(radius, start):
+            yield (x % w, y % h)
 
     @property
     @overrides(Machine.wrap)

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -136,9 +136,8 @@ class HorizontalWrapMachine(Machine):
     def concentric_chips(self, radius, start):
         # Aliases for convenience
         w = self._width
-        sx, sy = start
-        for (x, y) in self._basic_concentric_chips(radius):
-            yield ((sx + x) % w, sy + y)
+        for (x, y) in self._basic_concentric_chips(radius, start):
+            yield (x % w, y)
 
     @property
     @overrides(Machine.wrap)

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -132,8 +132,8 @@ class HorizontalWrapMachine(Machine):
         else:
             return self._minimize_vector(x_left, y)
 
-    @overrides(Machine.concentric_chips)
-    def concentric_chips(self, radius, start):
+    @overrides(Machine.concentric_xys)
+    def concentric_xys(self, radius, start):
         # Aliases for convenience
         w = self._width
         for (x, y) in self._basic_concentric_chips(radius, start):

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -136,7 +136,7 @@ class HorizontalWrapMachine(Machine):
     def concentric_xys(self, radius, start):
         # Aliases for convenience
         w = self._width
-        for (x, y) in self._basic_concentric_chips(radius, start):
+        for (x, y) in self._basic_concentric_xys(radius, start):
             yield (x % w, y)
 
     @property

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -147,6 +147,14 @@ class HorizontalWrapMachine(Machine):
         else:
             return self._minimize_vector(x_left, y)
 
+    @overrides(Machine.concentric_chips)
+    def concentric_chips(self, radius, start):
+        # Aliases for convenience
+        w = self._width
+        sx, sy = start
+        for (x, y) in self._basic_concentric_chips(radius):
+            yield ((sx + x) % w, sy + y)
+
     @property
     @overrides(Machine.wrap)
     def wrap(self):

--- a/spinn_machine/ignores/ignore_core.py
+++ b/spinn_machine/ignores/ignore_core.py
@@ -62,12 +62,30 @@ class IgnoreCore(object):
             return TYPICAL_PHYSICAL_VIRTUAL_MAP[0-self.p]
 
     @staticmethod
+    def parse_cores(core_string):
+        """ Parses the "core" part of a string, which might be a single core,
+            or otherwise is a range of cores
+
+        :param str: A string to parse
+        :return: A list of cores, which might be just one
+        :rtype: list(int)
+        """
+        if core_string.contains('-'):
+            parts = core_string.split("-")
+            if len(parts) == 2:
+                return range(int(parts[0]), int(parts[1] + 1))
+            raise Exception("Unexpected down core range: {}".format(
+                core_string))
+        return [int(core_string)]
+
+    @staticmethod
     def parse_single_string(downed_core):
         """ Converts a string into an :py:class:`IgnoreCore` object
 
         The format is::
 
-            <down_core> = <chip_x>,<chip_y>,<core_id>[,<ip>]
+            <down_core_id> = <chip_x>,<chip_y>,(<core_id>|<core_range>)[,<ip>]
+            <core_range> = <core_id>-<core_id>
 
         where:
 
@@ -85,15 +103,17 @@ class IgnoreCore(object):
             6,5,-2,10.11.12.13
 
         :param str downed_core: representation of one chip to ignore
-        :return: An IgnoreCore object
-        :rtype: IgnoreCore
+        :return: A list of IgnoreCore objects
+        :rtype: list(IgnoreCore)
         """
         parts = downed_core.split(",")
 
         if len(parts) == 3:
-            return IgnoreCore(parts[0], parts[1], parts[2])
+            return [IgnoreCore(parts[0], parts[1], core)
+                    for core in IgnoreCore.parse_core(parts[2])]
         elif len(parts) == 4:
-            return IgnoreCore(parts[0], parts[1], parts[2], parts[3])
+            return [IgnoreCore(parts[0], parts[1], core, parts[3])
+                    for core in IgnoreCore.parse_core(parts[2])]
         else:
             raise Exception(
                 "Unexpected downed_core: {}".format(downed_core))
@@ -106,7 +126,8 @@ class IgnoreCore(object):
         The format is:
 
             down_cores = <down_core_id>[:<down_core_id]*
-            <down_core_id> = <chip_x>,<chip_y>[,<ip>]
+            <down_core_id> = <chip_x>,<chip_y>,(<core_id>|<core_range>)[,<ip>]
+            <core_range> = <core_id>-<core_id>
 
         where:
 
@@ -122,7 +143,7 @@ class IgnoreCore(object):
 
         An example::
 
-            4,7,3:6,5,-2,10.11.12.13
+            4,7,3:6,5,-2,10.11.12.13,2,3,2-17
 
         :param str downed_cores: representation of zero or chips to ignore
         :return: Set (possibly empty) of IgnoreCores
@@ -134,5 +155,5 @@ class IgnoreCore(object):
         if downed_cores.lower() == "none":
             return ignored_cores
         for downed_chip in downed_cores.split(":"):
-            ignored_cores.add(IgnoreCore.parse_single_string(downed_chip))
+            ignored_cores.update(IgnoreCore.parse_single_string(downed_chip))
         return ignored_cores

--- a/spinn_machine/ignores/ignore_core.py
+++ b/spinn_machine/ignores/ignore_core.py
@@ -12,10 +12,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import re
 
 TYPICAL_PHYSICAL_VIRTUAL_MAP = {
     0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 0, 11: 12,
     12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18}
+
+CORE_RANGE = re.compile("(\d+)-(\d+)")
 
 
 class IgnoreCore(object):
@@ -70,12 +73,9 @@ class IgnoreCore(object):
         :return: A list of cores, which might be just one
         :rtype: list(int)
         """
-        if core_string.contains('-'):
-            parts = core_string.split("-")
-            if len(parts) == 2:
-                return range(int(parts[0]), int(parts[1] + 1))
-            raise Exception("Unexpected down core range: {}".format(
-                core_string))
+        result = CORE_RANGE.fullmatch(core_string)
+        if result is not None:
+            return range(int(result.group(1)), int(result.group(2)) + 1)
         return [int(core_string)]
 
     @staticmethod
@@ -110,10 +110,10 @@ class IgnoreCore(object):
 
         if len(parts) == 3:
             return [IgnoreCore(parts[0], parts[1], core)
-                    for core in IgnoreCore.parse_core(parts[2])]
+                    for core in IgnoreCore.parse_cores(parts[2])]
         elif len(parts) == 4:
             return [IgnoreCore(parts[0], parts[1], core, parts[3])
-                    for core in IgnoreCore.parse_core(parts[2])]
+                    for core in IgnoreCore.parse_cores(parts[2])]
         else:
             raise Exception(
                 "Unexpected downed_core: {}".format(downed_core))

--- a/spinn_machine/ignores/ignore_core.py
+++ b/spinn_machine/ignores/ignore_core.py
@@ -18,7 +18,7 @@ TYPICAL_PHYSICAL_VIRTUAL_MAP = {
     0: 1, 1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7, 7: 8, 8: 9, 9: 10, 10: 0, 11: 12,
     12: 13, 13: 14, 14: 15, 15: 16, 16: 17, 17: 18}
 
-CORE_RANGE = re.compile("(\d+)-(\d+)")
+CORE_RANGE = re.compile(r"(\d+)-(\d+)")
 
 
 class IgnoreCore(object):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -452,6 +452,19 @@ class Machine(object, metaclass=AbstractBase):
         :return:
         """
 
+    @abstractmethod
+    def concentric_chips(self, radius, start):
+        """ A generator that produces coordinates for concentric rings of chips
+            based on the links of the chips.
+
+            Mostly copied from:
+            https://github.com/project-rig/blob/master/rig/geometry.py
+
+        :param int radius: The radius of rings to produce (0 = start only)
+        :param tuple(int,int) start: The start coordinate
+        :rtype: tuple(int,int)
+        """
+
     def validate(self):
         """
         Validates the machine and raises an exception in unexpected conditions.
@@ -1170,3 +1183,19 @@ class Machine(object, metaclass=AbstractBase):
                 if xy not in self._chips and xy not in xys_by_ethernet:
                     return xy
             x += 1
+
+    def _basic_concentric_chips(self, radius):
+        """ Generates concentric chips from 0, 0 without accounting for wrap
+            around
+        """
+        x, y = (0, 0)
+        yield (x, y)
+        for r in range(1, radius + 1):
+            # Move to the next layer
+            y -= 1
+            # Walk around the chips at this radius
+            for dx, dy in [(1, 1), (0, 1), (-1, 0), (-1, -1), (0, -1), (1, 0)]:
+                for _ in range(r):
+                    yield (x, y)
+                    x += dx
+                    y += dy

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -482,12 +482,16 @@ class Machine(object, metaclass=AbstractBase):
         """
 
     @abstractmethod
-    def concentric_chips(self, radius, start):
-        """ A generator that produces coordinates for concentric rings of chips
-            based on the links of the chips.
+    def concentric_xys(self, radius, start):
+        """
+        A generator that produces coordinates for concentric rings of
+            possible chips based on the links of the chips.
 
-            Mostly copied from:
-            https://github.com/project-rig/rig/blob/master/rig/geometry.py
+        No check is done to see if the chip exists.
+        This may even produce coordinates with negative numbers
+
+        Mostly copied from:
+        https://github.com/project-rig/rig/blob/master/rig/geometry.py
 
         :param int radius: The radius of rings to produce (0 = start only)
         :param tuple(int,int) start: The start coordinate
@@ -1212,9 +1216,14 @@ class Machine(object, metaclass=AbstractBase):
                     return xy
             x += 1
 
-    def _basic_concentric_chips(self, radius, start):
-        """ Generates concentric chips from 0, 0 without accounting for wrap
-            around
+    def _basic_concentric_xys(self, radius, start):
+        """ Generates concentric xys from start without accounting for wrap
+            around or checking if the chip exists
+
+        :param int radius: The radius of rings to produce (0 = start only)
+        :param tuple(int,int) start: The start coordinate
+        :rtype: tuple(int,int)
+
         """
         x, y = start
         yield (x, y)

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -1212,11 +1212,11 @@ class Machine(object, metaclass=AbstractBase):
                     return xy
             x += 1
 
-    def _basic_concentric_chips(self, radius):
+    def _basic_concentric_chips(self, radius, start):
         """ Generates concentric chips from 0, 0 without accounting for wrap
             around
         """
-        x, y = (0, 0)
+        x, y = start
         yield (x, y)
         for r in range(1, radius + 1):
             # Move to the next layer

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -487,7 +487,7 @@ class Machine(object, metaclass=AbstractBase):
             based on the links of the chips.
 
             Mostly copied from:
-            https://github.com/project-rig/blob/master/rig/geometry.py
+            https://github.com/project-rig/rig/blob/master/rig/geometry.py
 
         :param int radius: The radius of rings to produce (0 = start only)
         :param tuple(int,int) start: The start coordinate

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -226,7 +226,7 @@ class MulticastRoutingEntry(object):
         proc_entry = sum(1 << (Router.MAX_LINKS_PER_ROUTER + p)
                          for p in self._processor_ids)
         link_entry = sum(1 << link_id for link_id in self._link_ids)
-        proc_entry + link_entry
+        return proc_entry + link_entry
 
     def _calc_routing_ids(self):
         """ Convert a binary routing table entry usable on the machine to \

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -68,7 +68,7 @@ class MulticastRoutingEntry(object):
                 " is determined to be an error in the tool chain. Please "
                 "correct this and try again.")
 
-        # Add processor IDs, checking that there is only one of each
+        # Add processor IDs, ignore duplicates
         if spinnaker_route is None:
             self._processor_ids = set(processor_ids)
             self._link_ids = set(link_ids)

--- a/spinn_machine/multicast_routing_entry.py
+++ b/spinn_machine/multicast_routing_entry.py
@@ -223,10 +223,12 @@ class MulticastRoutingEntry(object):
 
         :rtype: int
         """
-        proc_entry = sum(1 << (Router.MAX_LINKS_PER_ROUTER + p)
-                         for p in self._processor_ids)
-        link_entry = sum(1 << link_id for link_id in self._link_ids)
-        return proc_entry + link_entry
+        route_entry = 0
+        for processor_id in self._processor_ids:
+            route_entry |= (1 << (Router.MAX_LINKS_PER_ROUTER + processor_id))
+        for link_id in self._link_ids:
+            route_entry |= (1 << link_id)
+        return route_entry
 
     def _calc_routing_ids(self):
         """ Convert a binary routing table entry usable on the machine to \

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -127,8 +127,7 @@ class NoWrapMachine(Machine):
     def concentric_chips(self, radius, start):
         # Aliases for convenience
         sx, sy = start
-        for (x, y) in self._basic_concentric_chips(radius):
-            yield (sx + x, sy + y)
+        return self._basic_concentric_chips(radius, start)
 
     @property
     @overrides(Machine.wrap)

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -127,7 +127,7 @@ class NoWrapMachine(Machine):
     def concentric_xys(self, radius, start):
         # Aliases for convenience
         sx, sy = start
-        return self._basic_concentric_chips(radius, start)
+        return self._basic_concentric_xys(radius, start)
 
     @property
     @overrides(Machine.wrap)

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -123,8 +123,8 @@ class NoWrapMachine(Machine):
         return self._minimize_vector(
             destination[0]-source[0], destination[1]-source[1])
 
-    @overrides(Machine.concentric_chips)
-    def concentric_chips(self, radius, start):
+    @overrides(Machine.concentric_xys)
+    def concentric_xys(self, radius, start):
         # Aliases for convenience
         sx, sy = start
         return self._basic_concentric_chips(radius, start)

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -138,6 +138,13 @@ class NoWrapMachine(Machine):
         return self._minimize_vector(
             destination[0]-source[0], destination[1]-source[1])
 
+    @overrides(Machine.concentric_chips)
+    def concentric_chips(self, radius, start):
+        # Aliases for convenience
+        sx, sy = start
+        for (x, y) in self._basic_concentric_chips(radius):
+            yield (sx + x, sy + y)
+
     @property
     @overrides(Machine.wrap)
     def wrap(self):

--- a/spinn_machine/processor.py
+++ b/spinn_machine/processor.py
@@ -107,20 +107,6 @@ class Processor(object):
         """
         return self._is_monitor
 
-    # is_monitor setter no longer available
-    # use Machine.set_reinjection_processors instead
-
-    def clone_as_system_processor(self):
-        """ Creates a clone of this processor but changing it to a system\
-            processor.
-
-        :return: A new Processor with the same properties INCLUDING the ID\
-            except now set as a System processor
-        :rtype: :py:class:`~spinn_machine.Processor`
-        """
-        return Processor(self._processor_id, self._clock_speed,
-                         is_monitor=True, dtcm_available=self._dtcm_available)
-
     def __str__(self):
         return "[CPU: id={}, clock_speed={} MHz, monitor={}]".format(
             self._processor_id, (self._clock_speed // 1000000),

--- a/spinn_machine/spinn_machine.cfg
+++ b/spinn_machine/spinn_machine.cfg
@@ -13,16 +13,20 @@ max_sdram_allowed_per_chip = None
 # This allows the actual machine found to be "repaired" to hide hardware faults.
 repair_machine = False
 
+# Software removal of a core/chip/link/all-cores-on-a-chip
 # format is:
 #    down_cores = <down_core_id>[:<down_core_id]*
-#    <down_core_id> = <chip_x>,<chip_y>,<core_id>[,<ip>]
+#    <down_core_id> = <chip_x>,<chip_y>,(<core_id>|<core_range>)[,<ip>]
+#    <core_range> = <core_id>-<core_id>]*
 #    down_chips = <down_chip_id>[:<down_chip_id]*
 #    <down_chip_id> = <chip_x>,<chip_y>[,<ip>]
 #    down_links = <down_link_id>:[:<down_link_id>]*
+     <down_link_id> = <chip_x>,<chip_y>,<link_id>[,<ip>]
 # where:
 #    <chip_x> is the x-coordinate of a down chip
 #    <chip_x> is the y-coordinate of a down chip
-#    <core_id> is the virtual core ID of a core if > 0 or the phsical core if <= 0
+#    <core_id> is the virtual core ID of a core if > 0 or the physical core if <= 0
+#    <link_id> is the link ID of a link between 0 and 5
 #    <ip> is an OPTIONAL ip address in the 127.0.0.0 format.
 #         If provided the <chip_x> <chip_y> will be considered local to the board with this ip address
 down_cores = None

--- a/spinn_machine/spinn_machine.cfg
+++ b/spinn_machine/spinn_machine.cfg
@@ -21,7 +21,7 @@ repair_machine = False
 #    down_chips = <down_chip_id>[:<down_chip_id]*
 #    <down_chip_id> = <chip_x>,<chip_y>[,<ip>]
 #    down_links = <down_link_id>:[:<down_link_id>]*
-     <down_link_id> = <chip_x>,<chip_y>,<link_id>[,<ip>]
+#     <down_link_id> = <chip_x>,<chip_y>,<link_id>[,<ip>]
 # where:
 #    <chip_x> is the x-coordinate of a down chip
 #    <chip_x> is the y-coordinate of a down chip

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -147,6 +147,14 @@ class VerticalWrapMachine(Machine):
         else:
             return self._minimize_vector(x, y_down)
 
+    @overrides(Machine.concentric_chips)
+    def concentric_chips(self, radius, start):
+        # Aliases for convenience
+        h = self._height
+        sx, sy = start
+        for (x, y) in self._basic_concentric_chips(radius):
+            yield (sx + x, (sy + y) % h)
+
     @property
     @overrides(Machine.wrap)
     def wrap(self):

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -136,9 +136,8 @@ class VerticalWrapMachine(Machine):
     def concentric_chips(self, radius, start):
         # Aliases for convenience
         h = self._height
-        sx, sy = start
-        for (x, y) in self._basic_concentric_chips(radius):
-            yield (sx + x, (sy + y) % h)
+        for (x, y) in self._basic_concentric_chips(radius, start):
+            yield (x, y % h)
 
     @property
     @overrides(Machine.wrap)

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -132,8 +132,8 @@ class VerticalWrapMachine(Machine):
         else:
             return self._minimize_vector(x, y_down)
 
-    @overrides(Machine.concentric_chips)
-    def concentric_chips(self, radius, start):
+    @overrides(Machine.concentric_xys)
+    def concentric_xys(self, radius, start):
         # Aliases for convenience
         h = self._height
         for (x, y) in self._basic_concentric_chips(radius, start):

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -136,7 +136,7 @@ class VerticalWrapMachine(Machine):
     def concentric_xys(self, radius, start):
         # Aliases for convenience
         h = self._height
-        for (x, y) in self._basic_concentric_chips(radius, start):
+        for (x, y) in self._basic_concentric_xys(radius, start):
             yield (x, y % h)
 
     @property

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -17,6 +17,7 @@
 test for testing the python representation of a spinnaker machine
 """
 import unittest
+from unittest import SkipTest
 from spinn_machine import (
     Link, SDRAM, Router, Chip, Machine, machine_from_chips, machine_from_size)
 from spinn_machine.config_setup import unittest_setup
@@ -381,6 +382,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertFalse((1, 9) in machine)
 
     def test_virtual_chips(self):
+        raise SkipTest("virtual chips to be removed")
         machine = machine_from_size(8, 8)
         v1 = Chip(
             n_processors=128, sdram=SDRAM(size=0), x=6, y=6, virtual=True,

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -395,10 +395,10 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertIn(v2, virtuals)
         self.assertEqual(len(virtuals), 2)
 
-    def test_concentric_chips(self):
+    def test_concentric_xys(self):
         chips = self._create_chips()
         machine = machine_from_chips(chips)
-        found = list(machine.concentric_chips(2, (2, 2)))
+        found = list(machine.concentric_xys(2, (2, 2)))
         expected = [
             (2, 2),
             (2, 1), (3, 2), (3, 3), (2, 3), (1, 2), (1, 1),

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -395,6 +395,17 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertIn(v2, virtuals)
         self.assertEqual(len(virtuals), 2)
 
+    def test_concentric_chips(self):
+        chips = self._create_chips()
+        machine = machine_from_chips(chips)
+        found = list(machine.concentric_chips(2, (2, 2)))
+        expected = [
+            (2, 2),
+            (2, 1), (3, 2), (3, 3), (2, 3), (1, 2), (1, 1),
+            (2, 0), (3, 1), (4, 2), (4, 3), (4, 4), (3, 4),
+            (2, 4), (1, 3), (0, 2), (0, 1), (0, 0), (1, 0)]
+        self.assertListEqual(expected, found)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittests/test_multicast_routing_entry.py
+++ b/unittests/test_multicast_routing_entry.py
@@ -65,48 +65,6 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(multicast3.link_ids, [2, 3, 5])
         self.assertEqual(multicast3.processor_ids, [1, 3, 4, 16])
 
-    def test_duplicate_processors_ids(self):
-        link_ids = list()
-        proc_ids = list()
-        for i in range(6):
-            link_ids.append(i)
-        for i in range(18):
-            proc_ids.append(i)
-        proc_ids.append(0)
-        key = 1
-        mask = 1
-        with self.assertRaises(SpinnMachineAlreadyExistsException) as e:
-            MulticastRoutingEntry(key, mask, proc_ids, link_ids, True)
-        self.assertEqual(e.exception.item, "processor ID")
-        self.assertEqual(e.exception.value, "0")
-
-    def test_duplicate_link_ids(self):
-        link_ids = list()
-        proc_ids = list()
-        for i in range(6):
-            link_ids.append(i)
-        link_ids.append(3)
-        for i in range(18):
-            proc_ids.append(i)
-        key = 1
-        mask = 1
-        with self.assertRaises(SpinnMachineAlreadyExistsException):
-            MulticastRoutingEntry(key, mask, proc_ids, link_ids, True)
-
-    def test_duplicate_link_ids_and_proc_ids(self):
-        link_ids = list()
-        proc_ids = list()
-        for i in range(6):
-            link_ids.append(i)
-        link_ids.append(3)
-        for i in range(18):
-            proc_ids.append(i)
-        proc_ids.append(0)
-        key = 1
-        mask = 1
-        with self.assertRaises(SpinnMachineAlreadyExistsException):
-            MulticastRoutingEntry(key, mask, proc_ids, link_ids, True)
-
     def test_merger(self):
         link_ids = list()
         link_ids2 = list()

--- a/unittests/test_multicast_routing_entry.py
+++ b/unittests/test_multicast_routing_entry.py
@@ -17,8 +17,7 @@ import pickle
 import unittest
 from spinn_machine import MulticastRoutingEntry
 from spinn_machine.config_setup import unittest_setup
-from spinn_machine.exceptions import (
-    SpinnMachineAlreadyExistsException, SpinnMachineInvalidParameterException)
+from spinn_machine.exceptions import SpinnMachineInvalidParameterException
 
 
 class TestMulticastRoutingEntry(unittest.TestCase):

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -954,8 +954,8 @@ class TestVirtualMachine(unittest.TestCase):
 
     def test_ignores(self):
         set_config("Machine", "down_chips", "2,2:4,4:6,6,ignored_ip")
-        set_config(
-            "Machine", "down_cores", "1,1,1:3,3,3: 5,5,-5:7,7,7,ignored_ip")
+        set_config("Machine", "down_cores",
+                   "1,1,1:3,3,3: 5,5,-5:7,7,7,ignored_ip:0,0,5-10")
         set_config("Machine", "down_links", "1,3,3:3,5,3:5,3,3,ignored_ip")
 
         machine = virtual_machine(8, 8)
@@ -963,6 +963,7 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertFalse(machine.is_chip_at(4, 4))
         self.assertFalse(machine.is_chip_at(2, 2))
         self.assertTrue(machine.is_chip_at(6, 6))
+        self.assertTrue(machine.is_chip_at(0, 0))
 
         chip = machine.get_chip_at(3, 3)
         self.assertFalse(chip.is_processor_with_id(3))
@@ -984,6 +985,14 @@ class TestVirtualMachine(unittest.TestCase):
 
         router = machine.get_chip_at(5, 3).router
         self.assertTrue(router.is_link(3))
+
+        chip = machine.get_chip_at(0, 0)
+        for i in range(0, 5):
+            self.assertTrue(chip.is_processor_with_id(i))
+        for i in range(5, 11):
+            self.assertFalse(chip.is_processor_with_id(i))
+        for i in range(12, 18):
+            self.assertTrue(chip.is_processor_with_id(i))
 
     def test_bad_ignores(self):
         try:


### PR DESCRIPTION
Adds a few useful things to the machine including:
1) A way to get concentric rings in a machine 
2) Ignore core ranges (useful to essentially remove a chip but still leave enough to route through it)
3) Not cause errors on duplicate links / processors, but instead just use sets to avoid issues
4) Remove an unused function that got a system processor.