### PR TITLE
Extdev fpgas

### DIFF
--- a/spinn_machine/full_wrap_machine.py
+++ b/spinn_machine/full_wrap_machine.py
@@ -47,8 +47,7 @@ class FullWrapMachine(Machine):
         for (x, y) in self._local_xys:
             chip_xy = ((x + ethernet_x) % self._width,
                        (y + ethernet_y) % self._height)
-            if chip_xy in self._chips and\
-                    chip_xy not in self._virtual_chips:
+            if chip_xy in self._chips:
                 yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)

--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -40,8 +40,7 @@ class HorizontalWrapMachine(Machine):
         for (x, y) in self._local_xys:
             chip_xy = ((x + ethernet_x) % self._width,
                        (y + ethernet_y))
-            if chip_xy in self._chips and \
-                    chip_xy not in self._virtual_chips:
+            if chip_xy in self._chips:
                 yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -15,7 +15,7 @@
 
 import logging
 import json
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from spinn_utilities.log import FormatAdapter
 from spinn_machine.data import MachineDataView
 from .chip import Chip
@@ -138,40 +138,12 @@ def _int_value(value):
         return JAVA_MAX_INT
 
 
-def _find_virtual_links(machine):
-    """ Find all the virtual links and their inverse.
-
-    As these may well go to an unexpected source
-
-    :param machine: Machine to convert
-    :return: Map of Chip to list of virtual links
-    """
-    virtual_links_dict = defaultdict(list)
-    for chip in machine.virtual_chips:
-        # assume all links need special treatment
-        for link in chip.router.links:
-            virtual_links_dict[chip].append(link)
-            # Find and save inverse link as well
-            inverse_id = ((link.source_link_id + OPPOSITE_LINK_OFFSET) %
-                          Router.MAX_LINKS_PER_ROUTER)
-            destination = machine.get_chip_at(
-                link.destination_x, link.destination_y)
-            inverse_link = destination.router.get_link(inverse_id)
-            # Because some virtual chips are branched at an FPGA, only do this
-            # if the destination chip is *only* linked to the virtual chip
-            if (inverse_link.destination_x == chip.x and
-                    inverse_link.destination_y == chip.y):
-                virtual_links_dict[destination].append(inverse_link)
-    return virtual_links_dict
-
-
-def _describe_chip(chip, std, eth, virtual_links_dict):
+def _describe_chip(chip, std, eth):
     """ Produce a JSON-suitable description of a single chip.
 
     :param chip: The chip to describe.
     :param std: The standard chip resources.
     :param eth: The standard ethernet chip resources.
-    :param virtual_links_dict: Where the virtual links are.
     :return: Description of chip that is trivial to serialize as JSON.
     """
     details = dict()
@@ -186,16 +158,6 @@ def _describe_chip(chip, std, eth, virtual_links_dict):
             dead_links.append(link_id)
     if dead_links:
         details["deadLinks"] = dead_links
-
-    if chip in virtual_links_dict:
-        links = []
-        for link in virtual_links_dict[chip]:
-            link_details = dict()
-            link_details["sourceLinkId"] = link.source_link_id
-            link_details["destinationX"] = link.destination_x
-            link_details["destinationY"] = link.destination_y
-            links.append(link_details)
-        details["links"] = links
 
     exceptions = dict()
     router_entries = _int_value(
@@ -292,12 +254,9 @@ def to_json():
     json_obj["ethernetResources"] = ethernet_resources
     json_obj["chips"] = []
 
-    virtual_links_dict = _find_virtual_links(machine)
-
     # handle chips
     for chip in machine.chips:
-        json_obj["chips"].append(_describe_chip(
-            chip, std, eth, virtual_links_dict))
+        json_obj["chips"].append(_describe_chip(chip, std, eth))
 
     return json_obj
 

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -156,9 +156,11 @@ def _find_virtual_links(machine):
             destination = machine.get_chip_at(
                 link.destination_x, link.destination_y)
             inverse_link = destination.router.get_link(inverse_id)
-            assert(inverse_link.destination_x == chip.x)
-            assert(inverse_link.destination_y == chip.y)
-            virtual_links_dict[destination].append(inverse_link)
+            # Because some virtual chips are branched at an FPGA, only do this
+            # if the destination chip is *only* linked to the virtual chip
+            if (inverse_link.destination_x == chip.x and
+                    inverse_link.destination_y == chip.y):
+                virtual_links_dict[destination].append(inverse_link)
     return virtual_links_dict
 
 

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -803,10 +803,16 @@ class Machine(object, metaclass=AbstractBase):
         """
         # Try chip coordinates first
         if chip_coords is not None:
+            if chip_coords not in self._chips:
+                raise KeyError(f"No chip {chip_coords} found!")
             key = (chip_coords, spinnaker_link_id)
             link_data = self._spinnaker_links.get(key, None)
             if link_data is not None:
                 return link_data
+            if board_address is None:
+                raise KeyError(
+                    f"SpiNNaker link {spinnaker_link_id} not found"
+                    f" on chip {chip_coords}")
 
         # Otherwise try board address
         if board_address is None:

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -766,7 +766,7 @@ class Machine(object, metaclass=AbstractBase):
         if board_address is None:
             board_address = self._boot_ethernet_address
         key = (board_address, spinnaker_link_id)
-        return self.__spinnaker_links.get(key, None)
+        return self._spinnaker_links.get(key, None)
 
     def get_fpga_link_with_id(
             self, fpga_id, fpga_link_id, board_address=None, chip_coords=None):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -67,7 +67,7 @@ class Machine(object, metaclass=AbstractBase):
         "_chips",
         "_ethernet_connected_chips",
         "_fpga_links",
-        # Declared height of the machine excluding virtual chips
+        # Declared height of the machine
         # This can not be changed
         "_height",
         # List of the possible chips (x,y) on each board of the machine
@@ -83,8 +83,7 @@ class Machine(object, metaclass=AbstractBase):
         "_origin",
         "_spinnaker_links",
         "_maximum_user_cores_on_chip",
-        "_virtual_chips",
-        # Declared width of the machine excluding virtual chips
+        # Declared width of the machine
         # This can not be changed
         "_width"
     )
@@ -178,8 +177,6 @@ class Machine(object, metaclass=AbstractBase):
         self._chips = dict()
         if chips is not None:
             self.add_chips(chips)
-
-        self._virtual_chips = dict()
 
         if origin is None:
             self._origin = ""
@@ -603,13 +600,6 @@ class Machine(object, metaclass=AbstractBase):
 
         if chip.n_user_processors > self._maximum_user_cores_on_chip:
             self._maximum_user_cores_on_chip = chip.n_user_processors
-
-    def add_virtual_chip(self, chip):
-        """
-        :param ~spinn_machine.Chip chip: The virtual chip to add
-        """
-        self._virtual_chips[(chip.x, chip.y)] = chip
-        self.add_chip(chip)
 
     def add_chips(self, chips):
         """ Add some chips to the machine
@@ -1225,13 +1215,6 @@ class Machine(object, metaclass=AbstractBase):
                     return (0, y - x, -x)
                 else:
                     return (x - y, 0, -y)
-
-    @property
-    def virtual_chips(self):
-        """
-        :rtype: iterable(Chip)
-        """
-        return self._virtual_chips.values()
 
     @property
     def local_xys(self):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -799,7 +799,7 @@ class Machine(object, metaclass=AbstractBase):
             unsuccessful.
         :type chip_coords: tuple(int, int) or None
         :return: The SpiNNaker link data or None if no link
-        :rtype: ~spinn_machine.link_data_objects.SpinnakerLinkData or None
+        :rtype: ~spinn_machine.link_data_objects.SpinnakerLinkData
         """
         # Try chip coordinates first
         if chip_coords is not None:
@@ -812,7 +812,11 @@ class Machine(object, metaclass=AbstractBase):
         if board_address is None:
             board_address = self._boot_ethernet_address
         key = (board_address, spinnaker_link_id)
-        return self._spinnaker_links.get(key, None)
+        if key not in self._spinnaker_links:
+            raise KeyError(
+                f"SpiNNaker Link {spinnaker_link_id} does not exist on board"
+                f" {board_address}")
+        return self._spinnaker_links[key]
 
     def get_fpga_link_with_id(
             self, fpga_id, fpga_link_id, board_address=None, chip_coords=None):
@@ -838,7 +842,7 @@ class Machine(object, metaclass=AbstractBase):
             used first, with board_address only used if this is unsuccessful.
         :type chip_coords: tuple(int, int) or None
         :return: the given FPGA link object or ``None`` if no such link
-        :rtype: ~spinn_machine.link_data_objects.FPGALinkData or None
+        :rtype: ~spinn_machine.link_data_objects.FPGALinkData
         """
         # Try chip coordinates first
         if chip_coords is not None:
@@ -851,7 +855,11 @@ class Machine(object, metaclass=AbstractBase):
         if board_address is None:
             board_address = self._boot_ethernet_address
         key = (board_address, fpga_id, fpga_link_id)
-        return self._fpga_links.get(key, None)
+        if key not in self._fpga_links:
+            raise KeyError(
+                f"FPGA Link {fpga_id}:{fpga_link_id} does not exist on board"
+                f" {board_address}")
+        return self._fpga_links[key]
 
     def add_spinnaker_links(self):
         """ Add SpiNNaker links that are on a given machine depending on the\

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -743,11 +743,14 @@ class Machine(object, metaclass=AbstractBase):
         :param int spinnaker_link_id: The ID of the link
         :param board_address:
             optional board address that this SpiNNaker link is associated with.
-            Overridden by  chip_coords if both are specified.
+            If both this and chip_coords are specified, chip_coords will be
+            used first, with board_address only used if this is unsuccessful.
         :type board_address: str or None
         :param chip_coords:
             optional chip coordinates that this SpiNNaker link is associated
-            with.  Overrides board_address is both are specified.
+            with.  If both this and board_address are specified, chip_coords
+            will be used first, with board_address only used if this is
+            unsuccessful.
         :type chip_coords: tuple(int, int) or None
         :return: The SpiNNaker link data or None if no link
         :rtype: ~spinn_machine.link_data_objects.SpinnakerLinkData or None
@@ -780,11 +783,13 @@ class Machine(object, metaclass=AbstractBase):
             https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
         :param board_address:
             optional board address that this FPGA link is associated with.
-            Overridden by chip_coords if both are specified.
+            If both this and chip_coords are specified, chip_coords will be
+            used first, with board_address only used if this is unsuccessful.
         :type board_address: str or None
         :param chip_coords:
             optional chip coordinates that this FPGA link is associated with.
-            Overrides board_address if both are specified.
+            If both this and board_address are specified, chip_coords will be
+            used first, with board_address only used if this is unsuccessful.
         :type chip_coords: tuple(int, int) or None
         :return: the given FPGA link object or ``None`` if no such link
         :rtype: ~spinn_machine.link_data_objects.FPGALinkData or None

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -859,7 +859,7 @@ class Machine(object, metaclass=AbstractBase):
 
     # pylint: disable=too-many-arguments
     def _add_fpga_link(self, fpga_id, fpga_link, x, y, link, board_address):
-        if self.is_chip_at(x, y) and not self.is_link_at(x, y, link):
+        if self.is_chip_at(x, y):
             self._fpga_links[board_address, fpga_id, fpga_link] = \
                 FPGALinkData(
                     fpga_link_id=fpga_link, fpga_id=fpga_id,

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -846,10 +846,16 @@ class Machine(object, metaclass=AbstractBase):
         """
         # Try chip coordinates first
         if chip_coords is not None:
+            if chip_coords not in self._chips:
+                raise KeyError(f"No chip {chip_coords} found!")
             key = (chip_coords, fpga_id, fpga_link_id)
             link_data = self._fpga_links.get(key, None)
             if link_data is not None:
                 return link_data
+            if board_address is None:
+                raise KeyError(
+                    f"FPGA {fpga_id}, link {fpga_link_id} not found"
+                    f" on chip {chip_coords}")
 
         # Otherwise try board address
         if board_address is None:

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -880,28 +880,32 @@ class Machine(object, metaclass=AbstractBase):
                     for _ in range(4):
                         fx = (x + ex) % (self._max_chip_x + 1)
                         fy = (y + ey) % (self._max_chip_y + 1)
-                        self._add_fpga_link(f, lk, fx, fy, l1, ip)
+                        self._add_fpga_link(f, lk, fx, fy, l1, ip, ex, ey)
                         f, lk = self._next_fpga_link(f, lk)
                         if i % 2 == 1:
                             x += dx
                             y += dy
                         fx = (x + ex) % (self._max_chip_x + 1)
                         fy = (y + ey) % (self._max_chip_y + 1)
-                        self._add_fpga_link(f, lk, fx, fy, l2, ip)
+                        self._add_fpga_link(f, lk, fx, fy, l2, ip, ex, ey)
                         f, lk = self._next_fpga_link(f, lk)
                         if i % 2 == 0:
                             x += dx
                             y += dy
 
     # pylint: disable=too-many-arguments
-    def _add_fpga_link(self, fpga_id, fpga_link, x, y, link, board_address):
+    def _add_fpga_link(self, fpga_id, fpga_link, x, y, link, board_address,
+                       ex, ey):
         if self.is_chip_at(x, y):
             link_data = FPGALinkData(
                 fpga_link_id=fpga_link, fpga_id=fpga_id,
                 connected_chip_x=x, connected_chip_y=y,
                 connected_link=link, board_address=board_address)
             self._fpga_links[board_address, fpga_id, fpga_link] = link_data
+            # Add for the exact chip coordinates
             self._fpga_links[(x, y), fpga_id, fpga_link] = link_data
+            # Add for the Ethernet chip coordinates to allow this to work too
+            self._fpga_links[(ex, ey), fpga_id, fpga_link] = link_data
 
     @staticmethod
     def _next_fpga_link(fpga_id, fpga_link):

--- a/spinn_machine/no_wrap_machine.py
+++ b/spinn_machine/no_wrap_machine.py
@@ -45,8 +45,7 @@ class NoWrapMachine(Machine):
     def get_existing_xys_by_ethernet(self, ethernet_x, ethernet_y):
         for (x, y) in self._local_xys:
             chip_xy = (x + ethernet_x, y + ethernet_y)
-            if chip_xy in self._chips and \
-                    chip_xy not in self._virtual_chips:
+            if chip_xy in self._chips:
                 yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)

--- a/spinn_machine/vertical_wrap_machine.py
+++ b/spinn_machine/vertical_wrap_machine.py
@@ -40,8 +40,7 @@ class VerticalWrapMachine(Machine):
         for (x, y) in self._local_xys:
             chip_xy = ((x + ethernet_x),
                        (y + ethernet_y) % self._height)
-            if chip_xy in self._chips and \
-                    chip_xy not in self._virtual_chips:
+            if chip_xy in self._chips:
                 yield chip_xy
 
     @overrides(Machine.get_down_xys_by_ethernet)

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -237,8 +237,10 @@ class SpinnMachineTestCase(unittest.TestCase):
             # but (0,4) is not on a standard 48-node board
             self.assertEqual(len(chips), 25)
             self.assertEqual(len(chips_in_machine), 24)
-        self.assertIsNone(new_machine.get_spinnaker_link_with_id(1))
-        self.assertIsNone(new_machine.get_fpga_link_with_id(1, 0))
+        with self.assertRaises(KeyError):
+            new_machine.get_spinnaker_link_with_id(1)
+        with self.assertRaises(KeyError):
+            self.assertIsNone(new_machine.get_fpga_link_with_id(1, 0))
 
     def test_x_y_over_link(self):
         """

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -17,7 +17,6 @@
 test for testing the python representation of a spinnaker machine
 """
 import unittest
-from unittest import SkipTest
 from spinn_machine import (
     Link, SDRAM, Router, Chip, Machine, machine_from_chips, machine_from_size)
 from spinn_machine.config_setup import unittest_setup

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -383,22 +383,6 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertTrue((1, 2) in machine)
         self.assertFalse((1, 9) in machine)
 
-    def test_virtual_chips(self):
-        raise SkipTest("virtual chips to be removed")
-        machine = machine_from_size(8, 8)
-        v1 = Chip(
-            n_processors=128, sdram=SDRAM(size=0), x=6, y=6, virtual=True,
-            nearest_ethernet_x=None, nearest_ethernet_y=None, router=None)
-        v2 = Chip(
-            n_processors=128, sdram=SDRAM(size=0), x=6, y=7, virtual=True,
-            nearest_ethernet_x=None, nearest_ethernet_y=None, router=None)
-        machine.add_virtual_chip(v1)
-        machine.add_virtual_chip(v2)
-        virtuals = list(machine.virtual_chips)
-        self.assertIn(v1, virtuals)
-        self.assertIn(v2, virtuals)
-        self.assertEqual(len(virtuals), 2)
-
     def test_concentric_xys(self):
         chips = self._create_chips()
         machine = machine_from_chips(chips)


### PR DESCRIPTION
Adds FPGAs and SpiNNaker links regardless of whether the links already exists.  This allows devices to be connected to these links even if other boards are, which is supported if the connection has a routing table in it.  Also adds the ability to specify the machine chip coordinates to which a device is connected, which can be easier for users.