### PR TITLE
Tweaks to route classes

### DIFF
--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -161,8 +161,10 @@ class Router(object):
         Convert a routing table entry represented in software to a
         binary routing table entry usable on the machine.
 
-        :param ~spinn_machine.MulticastRoutingEntry routing_table_entry:
+        :param routing_table_entry:
             The entry to convert
+        :type routing_table_entry: ~spinn_machine.MulticastRoutingEntry or
+             ~spinn_machine.FixedRouteEntry
         :rtype: int
         """
         route_entry = 0

--- a/unittests/test_multicast_routing_entry.py
+++ b/unittests/test_multicast_routing_entry.py
@@ -57,11 +57,11 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         multicast1 = MulticastRoutingEntry(1, 1, [1, 3, 4, 16], [2, 3, 5])
         self.assertEqual(4196012, multicast1.spinnaker_route)
         multicast2 = MulticastRoutingEntry(1, 1, spinnaker_route=4196012)
-        self.assertEqual(multicast2.processor_ids, [1, 3, 4, 16])
+        self.assertEqual(multicast2.processor_ids, {1, 3, 4, 16})
         # Third test getting the link_ids first
         multicast3 = MulticastRoutingEntry(1, 1, spinnaker_route=4196012)
-        self.assertEqual(multicast3.link_ids, [2, 3, 5])
-        self.assertEqual(multicast3.processor_ids, [1, 3, 4, 16])
+        self.assertEqual(multicast3.link_ids, {2, 3, 5})
+        self.assertEqual(multicast3.processor_ids, {1, 3, 4, 16})
 
     def test_merger(self):
         link_ids = list()


### PR DESCRIPTION
Sets really don't preserve order. They might pretend to in some circumstances, but they don't so we really shouldn't rely on it at all. Also, freeze key sets as we don't support modifying them anyway, and improve some doc comments