### PR TITLE
Make Chip support equality/hashing so we can use directly in sets/dicts

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -330,3 +330,12 @@ class Chip(object):
 
     def __repr__(self):
         return self.__str__()
+
+    def __eq__(self, other):
+        # Equality just on X,Y; that's most useful
+        if not isinstance(other, Chip):
+            return NotImplemented
+        return self._x == other.x and self._y == other.y
+
+    def __hash__(self):
+        return self._x * 256 + self._y


### PR DESCRIPTION
I'm not *sure* if this is necessary, but being able to use chips as keys simplifies a number of things and should reduce the amount of churn of tuples.

See:
* https://github.com/SpiNNakerManchester/SpiNNMan/pull/327
* https://github.com/SpiNNakerManchester/PACMAN/pull/513