### PR TITLE
remove Emergency routing 

### DIFF
--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -115,7 +115,7 @@ def machine_from_json(j_machine):
                 links.append(Link(
                     source_x, source_y, source_link_id, destination_x,
                     destination_y))
-        router = Router(links, False, router_entries)
+        router = Router(links, router_entries)
 
         # Create and add a chip with this router
         chip = Chip(

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -147,8 +147,7 @@ def _machine_ignore(original, dead_chips, dead_links):
             for link in chip.router.links:
                 if link.source_link_id not in links_map[(chip.x, chip.y)]:
                     links.append(link)
-            router = Router(links, chip.router.emergency_routing_enabled,
-                            chip.router.n_available_multicast_entries)
+            router = Router(links)
             chip = Chip(
                 chip.x, chip.y, chip.n_processors, router, chip.sdram,
                 chip.nearest_ethernet_x, chip.nearest_ethernet_y,

--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -35,9 +35,7 @@ class Router(object):
 
     MAX_CORES_PER_ROUTER = 18
 
-    __slots__ = ("_links",
-        "_n_available_multicast_entries"
-    )
+    __slots__ = ("_links", "_n_available_multicast_entries")
 
     def __init__(
             self, links, n_available_multicast_entries=Machine.ROUTER_ENTRIES):

--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -35,18 +35,14 @@ class Router(object):
 
     MAX_CORES_PER_ROUTER = 18
 
-    __slots__ = (
-        "_emergency_routing_enabled", "_links",
+    __slots__ = ("_links",
         "_n_available_multicast_entries"
     )
 
     def __init__(
-            self, links, emergency_routing_enabled=False,
-            n_available_multicast_entries=Machine.ROUTER_ENTRIES):
+            self, links, n_available_multicast_entries=Machine.ROUTER_ENTRIES):
         """
         :param iterable(~spinn_machine.Link) links: iterable of links
-        :param bool emergency_routing_enabled:
-            Determines if the router emergency routing is operating
         :param int n_available_multicast_entries:
             The number of entries available in the routing table
         :raise ~spinn_machine.exceptions.SpinnMachineAlreadyExistsException:
@@ -56,7 +52,6 @@ class Router(object):
         for link in links:
             self.add_link(link)
 
-        self._emergency_routing_enabled = emergency_routing_enabled
         self._n_available_multicast_entries = n_available_multicast_entries
 
     def add_link(self, link):
@@ -138,15 +133,6 @@ class Router(object):
         return len(self._links)
 
     @property
-    def emergency_routing_enabled(self):
-        """
-        Whether emergency routing is enabled.
-
-        :rtype: bool
-        """
-        return self._emergency_routing_enabled
-
-    @property
     def n_available_multicast_entries(self):
         """
         The number of available multicast entries in the routing tables.
@@ -216,7 +202,7 @@ class Router(object):
 
     def __str__(self):
         return (
-            f"[Router: emergency_routing={self._emergency_routing_enabled}, "
+            f"[Router: "
             f"available_entries={self._n_available_multicast_entries}, "
             f"links={list(self._links.values())}]")
 

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -186,8 +186,7 @@ class _VirtualMachine(object):
 
     def _create_chip(self, x, y, configured_chips, ip_address=None):
         chip_links = self._calculate_links(x, y, configured_chips)
-        chip_router = Router(
-            chip_links)
+        chip_router = Router(chip_links)
 
         (eth_x, eth_y, n_cores) = configured_chips[(x, y)]
 

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -58,7 +58,7 @@ class TestingChip(unittest.TestCase):
         self.assertEqual(
             new_chip.__repr__(),
             "[Chip: x=0, y=1, sdram=0 MB, ip_address=192.162.240.253, "
-            "router=[Router: emergency_routing=False, "
+            "router=[Router: "
             "available_entries=1024, links=["
             "[Link: source_x=0, source_y=0, source_link_id=0, "
             "destination_x=1, destination_y=1], "

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -34,7 +34,7 @@ class TestingChip(unittest.TestCase):
         links.append(Link(0, 1, 1, 1, 0))
         links.append(Link(1, 1, 2, 0, 0))
         links.append(Link(1, 0, 3, 0, 1))
-        self._router = Router(links, False, 1024)
+        self._router = Router(links, 1024)
 
         self._sdram = 128
         self._ip = "192.162.240.253"

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -37,7 +37,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         links.append(Link(0, 1, 1, 1, 0))
         links.append(Link(1, 1, 2, 0, 0))
         links.append(Link(1, 0, 3, 0, 1))
-        self._router = Router(links, False, 1024)
+        self._router = Router(links, 1024)
 
         self._nearest_ethernet_chip = (0, 0)
 

--- a/unittests/test_router.py
+++ b/unittests/test_router.py
@@ -30,7 +30,7 @@ class TestingRouter(unittest.TestCase):
         links.append(Link(0, 1, 1, 1, 0))
         links.append(Link(1, 1, 2, 0, 0))
         links.append(Link(1, 0, 3, 0, 1))
-        r = Router(links, False, 1024)
+        r = Router(links, 1024)
 
         self.assertEqual(len(r), 4)
         for i in range(4):
@@ -41,7 +41,6 @@ class TestingRouter(unittest.TestCase):
         self.assertEqual([link[0] for link in r], [0, 1, 2, 3])
         self.assertEqual([link[1].source_link_id for link in r], [0, 1, 2, 3])
 
-        self.assertFalse(r.emergency_routing_enabled)
         self.assertEqual(r.n_available_multicast_entries, 1024)
 
         self.assertFalse(r.is_link(-1))
@@ -65,21 +64,13 @@ class TestingRouter(unittest.TestCase):
             "[Link: source_x=1, source_y=0, source_link_id=3, "
             "destination_x=0, destination_y=1]]]")
 
-    def test_creating_new_router_with_emergency_routing_on(self):
-        links = list()
-        (e, ne, n, w, sw, s) = range(6)
-        links.append(Link(0, 0, 0, 0, 1))
-        links.append(Link(0, 1, 1, 0, 1))
-        r = Router(links, True, 1024)
-        self.assertTrue(r.emergency_routing_enabled)
-
     def test_creating_new_router_with_duplicate_links(self):
         links = list()
         (e, ne, n, w, sw, s) = range(6)
         links.append(Link(0, 0, 0, 0, 1))
         links.append(Link(0, 1, 0, 0, 1))
         with self.assertRaises(SpinnMachineAlreadyExistsException):
-            Router(links, False, 1024)
+            Router(links, 1024)
 
     def test_convert_to_route(self):
         e = MulticastRoutingEntry(28, 60, [4, 5, 7], [1, 3, 5], True)

--- a/unittests/test_router.py
+++ b/unittests/test_router.py
@@ -53,7 +53,7 @@ class TestingRouter(unittest.TestCase):
                           {'x': 0, 'y': 0}, {'x': 0, 'y': 1}])
         self.assertEqual(
             r.__repr__(),
-            "[Router: emergency_routing=False, "
+            "[Router: "
             "available_entries=1024, links=["
             "[Link: source_x=0, source_y=0, source_link_id=0, "
             "destination_x=1, destination_y=1], "

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -43,7 +43,7 @@ class TestVirtualMachine(unittest.TestCase):
         links.append(Link(0, 1, 1, 1, 0))
         links.append(Link(1, 1, 2, 0, 0))
         links.append(Link(1, 0, 3, 0, 1))
-        _router = Router(links, False, 1024)
+        _router = Router(links, 1024)
 
         _sdram = 128
         nearest_ethernet_chip = (0, 0)


### PR DESCRIPTION
the Router emergency_routing_enabled is never used.

So this PR remove it.

tested by 
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/spin_1_or_2/2/pipeline
