### PR TITLE
Defaults from cfg

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -80,6 +80,7 @@ class Chip(object):
         self._y = y
         self._p = self.__generate_processors(n_processors, down_cores)
         self._router = router
+        assert sdram
         self._sdram = sdram
         self._ip_address = ip_address
         if tag_ids is not None:

--- a/spinn_machine/config_setup.py
+++ b/spinn_machine/config_setup.py
@@ -12,13 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from spinn_utilities.config_holder import (
     add_default_cfg, clear_cfg_files)
+from spinn_utilities.config_holder import get_config_int, set_config
 from spinn_utilities.config_setup import add_spinn_utilities_cfg
+from spinn_utilities.log import FormatAdapter
+from spinn_machine.data import MachineDataView
 from spinn_machine.data.machine_data_writer import MachineDataWriter
+from spinn_machine.exceptions import SpinnMachineException
 
 BASE_CONFIG_FILE = "spinn_machine.cfg"
+
+__SPIN1_SDRAM = 123469792
+
+# TODO FIX with correct values. These are INCORRECT
+__SPIN2_SDRAM = 1234567890
+
+logger = FormatAdapter(logging.getLogger(__name__))
 
 
 def unittest_setup():
@@ -40,3 +52,39 @@ def add_spinn_machine_cfg():
     """
     add_spinn_utilities_cfg()
     add_default_cfg(os.path.join(os.path.dirname(__file__), BASE_CONFIG_FILE))
+
+
+def __setup_spin(board_type, sdram):
+    """
+    Changes any board type settings to the Values required for a Spin1 board
+
+    :raises SpinnMachineException: If called after a Machine has been created
+    """
+    if MachineDataView.has_actual_machine():
+        raise SpinnMachineException("Illegal call once a Machine exists")
+    cfg_sdram = get_config_int("Machine", "max_sdram_allowed_per_chip")
+    if cfg_sdram is None:
+        set_config("Machine", "max_sdram_allowed_per_chip", sdram)
+    else:
+        if sdram != cfg_sdram:
+            logger.warning(
+                "Using sdram {cfg_sdram} from cfg which is different to "
+                f"the expected sdram of {sdram} for a {board_type} board.")
+
+
+def setup_spin1():
+    """
+    Changes any board type settings to the Values required for a Spin1 board
+
+    :raises SpinnMachineException: If called after a Machine has been created
+    """
+    __setup_spin("spin 1", __SPIN1_SDRAM)
+
+
+def setup_spin2():
+    """
+    Changes any board type settings to the Values required for a Spin2 board
+
+    :raises SpinnMachineException: If called after a Machine has been created
+    """
+    __setup_spin("spin_2", __SPIN2_SDRAM)

--- a/spinn_machine/config_setup.py
+++ b/spinn_machine/config_setup.py
@@ -33,25 +33,45 @@ __SPIN2_SDRAM = 1234567890
 logger = FormatAdapter(logging.getLogger(__name__))
 
 
-def unittest_setup():
+def unittest_setup(*, board_type=None):
     """
     Resets the configurations so only the local default configuration is
     included.
 
     .. note::
         This file should only be called from `SpiNNMachine/unittests`
+
+    :param board_type: Value to say how to confuire the system.
+        This includes defining what a VirtualMachine would be
+        Can be 1 for Spin1 boards, 2 for Spin2 boards or
+        None if the test do not depend on knowing the board type.
+    :type board_type: None or int
     """
     clear_cfg_files(True)
-    add_spinn_machine_cfg()
     MachineDataWriter.mock()
+    add_spinn_machine_cfg(board_type)
 
 
-def add_spinn_machine_cfg():
+def add_spinn_machine_cfg(board_type):
     """
     Add the local configuration and all dependent configuration files.
+
+    :param board_type: Value to say how to confuire the system.
+        This includes defining what a VirtualMachine would be
+        Can be 1 for Spin1 boards, 2 for Spin2 boards or
+        None if the test do not depend on knowing the board type.
+    :type board_type: None or int
     """
     add_spinn_utilities_cfg()
     add_default_cfg(os.path.join(os.path.dirname(__file__), BASE_CONFIG_FILE))
+    if board_type is None:
+        pass
+    elif board_type == 1:
+        setup_spin1()
+    elif board_type == 2:
+        setup_spin2()
+    else:
+        raise ValueError(f"Unexpected {board_type=}")
 
 
 def __setup_spin(board_type, sdram):
@@ -76,6 +96,10 @@ def setup_spin1():
     """
     Changes any board type settings to the Values required for a Spin1 board
 
+    .. note::
+        This method should only be called by ASB as part of sim.setup()
+        or here by unittest_setup. Any other usage is NOT supported!
+
     :raises SpinnMachineException: If called after a Machine has been created
     """
     __setup_spin("spin 1", __SPIN1_SDRAM)
@@ -84,6 +108,10 @@ def setup_spin1():
 def setup_spin2():
     """
     Changes any board type settings to the Values required for a Spin2 board
+
+    .. note::
+        This method should only be called by ASB as part of sim.setup()
+        or here by unittest_setup. Any other usage is NOT supported!
 
     :raises SpinnMachineException: If called after a Machine has been created
     """

--- a/spinn_machine/data/machine_data_view.py
+++ b/spinn_machine/data/machine_data_view.py
@@ -100,6 +100,15 @@ class MachineDataView(UtilsDataView):
                 cls._is_mocked())
 
     @classmethod
+    def has_actual_machine(cls):
+        """
+        Reports if a machine has actually been created.
+
+        :rtype: bool
+        """
+        return cls.__data._machine is not None
+
+    @classmethod
     def get_machine(cls):
         """
         Returns the Machine if it has been set.

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from spinn_utilities.log import FormatAdapter
 from .exceptions import (
     SpinnMachineAlreadyExistsException, SpinnMachineException)
 from spinn_machine.link_data_objects import FPGALinkData, SpinnakerLinkData
 from spinn_utilities.abstract_base import (
     AbstractBase, abstractproperty, abstractmethod)
-import logging
 
-logger = logging.getLogger(__name__)
+logger = FormatAdapter(logging.getLogger(__name__))
 
 
 class Machine(object, metaclass=AbstractBase):

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -44,7 +44,6 @@ class Machine(object, metaclass=AbstractBase):
     MAX_BANDWIDTH_PER_ETHERNET_CONNECTED_CHIP = 10 * 256
     DEFAULT_MAX_CORES_PER_CHIP = 18
     NON_USER_CORES = 1
-    DEFAULT_SDRAM_BYTES = 123469792
     __max_cores = None
     MAX_CHIPS_PER_48_BOARD = 48
     MAX_CHIPS_PER_4_CHIP_BOARD = 4

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -22,7 +22,6 @@ from .router import Router
 from .link import Link
 from .spinnaker_triad_geometry import SpiNNakerTriadGeometry
 from .machine_factory import machine_from_size
-from spinn_machine import Machine
 from spinn_machine.ignores import IgnoreChip, IgnoreCore, IgnoreLink
 
 logger = FormatAdapter(logging.getLogger(__name__))

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -102,8 +102,7 @@ class _VirtualMachine(object):
         # Store the details
         self._sdram_per_chip = get_config_int(
             "Machine", "max_sdram_allowed_per_chip")
-        if self._sdram_per_chip is None:
-            self._sdram_per_chip = Machine.DEFAULT_SDRAM_BYTES
+        assert self._sdram_per_chip
 
         # Store the down items
         unused_chips = []

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -15,7 +15,7 @@
 import unittest
 from spinn_utilities.exceptions import (DataNotYetAvialable)
 from spinn_machine import virtual_machine
-from spinn_machine.config_setup import unittest_setup, setup_spin1
+from spinn_machine.config_setup import unittest_setup
 from spinn_machine.data import MachineDataView
 from spinn_machine.data.machine_data_writer import MachineDataWriter
 
@@ -23,8 +23,7 @@ from spinn_machine.data.machine_data_writer import MachineDataWriter
 class TestSimulatorData(unittest.TestCase):
 
     def setUp(cls):
-        unittest_setup()
-        setup_spin1()
+        unittest_setup(board_type=1)
 
     def test_setup(self):
         # What happens before setup depends on the previous test

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -15,7 +15,7 @@
 import unittest
 from spinn_utilities.exceptions import (DataNotYetAvialable)
 from spinn_machine import virtual_machine
-from spinn_machine.config_setup import unittest_setup
+from spinn_machine.config_setup import unittest_setup, setup_spin1
 from spinn_machine.data import MachineDataView
 from spinn_machine.data.machine_data_writer import MachineDataWriter
 
@@ -24,6 +24,7 @@ class TestSimulatorData(unittest.TestCase):
 
     def setUp(cls):
         unittest_setup()
+        setup_spin1()
 
     def test_setup(self):
         # What happens before setup depends on the previous test

--- a/unittests/test_json_machine.py
+++ b/unittests/test_json_machine.py
@@ -17,7 +17,7 @@ import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
 from spinn_machine.data.machine_data_writer import MachineDataWriter
-from spinn_machine.config_setup import unittest_setup
+from spinn_machine.config_setup import unittest_setup, setup_spin1
 from spinn_machine.json_machine import (machine_from_json, to_json_path)
 
 
@@ -25,6 +25,7 @@ class TestJsonMachine(unittest.TestCase):
 
     def setUp(self):
         unittest_setup()
+        setup_spin1()
 
     def test_json_version_5_hole(self):
         set_config("Machine", "down_chips", "3,3")

--- a/unittests/test_json_machine.py
+++ b/unittests/test_json_machine.py
@@ -17,15 +17,14 @@ import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_machine import virtual_machine
 from spinn_machine.data.machine_data_writer import MachineDataWriter
-from spinn_machine.config_setup import unittest_setup, setup_spin1
+from spinn_machine.config_setup import unittest_setup
 from spinn_machine.json_machine import (machine_from_json, to_json_path)
 
 
 class TestJsonMachine(unittest.TestCase):
 
     def setUp(self):
-        unittest_setup()
-        setup_spin1()
+        unittest_setup(board_type=1)
 
     def test_json_version_5_hole(self):
         set_config("Machine", "down_chips", "3,3")

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -14,7 +14,7 @@
 
 import unittest
 from spinn_utilities.config_holder import set_config
-from spinn_machine.config_setup import unittest_setup
+from spinn_machine.config_setup import unittest_setup, setup_spin1
 from spinn_machine import (Chip, Link, Machine, machine_from_size, Router,
                            virtual_machine)
 from spinn_machine.exceptions import (
@@ -32,6 +32,7 @@ class TestVirtualMachine(unittest.TestCase):
 
     def setUp(self):
         unittest_setup()
+        setup_spin1()
 
     def _create_chip(self, x, y):
         # Create a list of processors.

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -14,7 +14,7 @@
 
 import unittest
 from spinn_utilities.config_holder import set_config
-from spinn_machine.config_setup import unittest_setup, setup_spin1
+from spinn_machine.config_setup import unittest_setup
 from spinn_machine import (Chip, Link, Machine, machine_from_size, Router,
                            virtual_machine)
 from spinn_machine.exceptions import (
@@ -31,8 +31,7 @@ class TestVirtualMachine(unittest.TestCase):
     TYPICAL_N_CORES_PER_BOARD = sum(Machine.CHIPS_PER_BOARD.values())
 
     def setUp(self):
-        unittest_setup()
-        setup_spin1()
+        unittest_setup(board_type=1)
 
     def _create_chip(self, x, y):
         # Create a list of processors.


### PR DESCRIPTION
Currently we have information about what the board/ default board/ virtual machine should be in various places.
This includes sdram per chip.

Once the ChipInfo is obtained from the board that Value should be used!
This is about where to store the information until ChipInfo is obtained.

As one place the information could be provided is the cfg the choice here is to use the [ConfigHolder](https://github.com/SpiNNakerManchester/SpiNNUtils/blob/master/spinn_utilities/config_holder.py) as the ONLY place to get the data until ChipInfo is read.

The standard way is for the Value in the cfg file to be None.
Then the [ConfigHandler](https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/blob/master/spinn_front_end_common/interface/config_handler.py) init called as part of sim.setup  will detect the board type and fill in the Values.
overrides in the cfg should only be used in testing or at the users risk,

Note: as we have not yet determined how to detect a spin2 board from cfg  [ConfigHandler](https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/blob/master/spinn_front_end_common/interface/config_handler.py) temporarily assumes spin1

The issue is then what to do with unittests that call sim.setup but do need the default values for example to create a VirtualMachine
The proposal is to have a board_type param in unittest_setup to determine which default Values to use.

There may be many unittest which only need A default and dont care which.
This could be extended for example to board_type=0 where something else is used to flip between testing spin1 vs testing spin 2. For example of the python_version as we run the tests in 4 version

Safety code checks that the the board_type is not changed while there is a Machine 
This required a second has_machine method as the existing one returned true for unittests as it one would be created on demand

The current spin2 values are WRONG! so included purely for demo

Other default Values including number of processors, number of Chip, number of montor cores ect to be added later

Must be done at the same time as:
https://github.com/SpiNNakerManchester/SpiNNMan/pull/341
https://github.com/SpiNNakerManchester/PACMAN/pull/518
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1086
https://github.com/SpiNNakerManchester/sPyNNaker/pull/1369
https://github.com/SpiNNakerManchester/SpiNNakerGraphFrontEnd/pull/254

tested by:

https://github.com/SpiNNakerManchester/IntegrationTests/pull/218





