### PR TITLE
Chip String fixes

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -333,7 +333,7 @@ class Chip(object):
         return (
             f"[Chip: x={self._x}, y={self._y}, {ip_info}"
             f"n_cores={self.n_processors}, "
-            f"mon={self.get_physical_core_id([0])}]")
+            f"mon={self.get_physical_core_id(0)}]")
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -326,13 +326,14 @@ class Chip(object):
         return self.is_processor_with_id(processor_id)
 
     def __str__(self) -> str:
+        if self._ip_address:
+            ip_info = f"ip_address={self.ip_address} "
+        else:
+            ip_info = ""
         return (
-            f"[Chip: x={self._x}, y={self._y}, "
-            f"sdram={self.sdram // (1024 * 1024)} MB, "
-            f"ip_address={self.ip_address}, router={self.router}, "
-            f"processors={list(self._p.values())}, "
-            f"nearest_ethernet={self._nearest_ethernet_x}:"
-            f"{self._nearest_ethernet_y}]")
+            f"[Chip: x={self._x}, y={self._y}, {ip_info}"
+            f"n_cores={self.n_processors}, "
+            f"mon={self.get_physical_core_id([0])}]")
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -230,7 +230,7 @@ def one_link_different_boards_msg(
 
 
 def __link_dead_chip(link: int, source: Chip, target_x: int, target_y: int,
-                      address: str) -> str:
+                     address: str) -> str:
     return f"Link {link} from {source} to {target_x}:{target_y} " \
            f"points to a dead chip. Chip {source.x}:" \
            f"{source.y} resides on board with ip address {address}. " \
@@ -238,7 +238,7 @@ def __link_dead_chip(link: int, source: Chip, target_x: int, target_y: int,
 
 
 def __chip_dead_parent_msg(
-        source: Chip, parent_x: int, parent_y: int, address : str) -> str:
+        source: Chip, parent_x: int, parent_y: int, address: str) -> str:
     return f"The {source: Chip} will fail to receive signals because its " \
            f"parent {parent_x}:{parent_y} in the signal tree has " \
            f"disappeared from the machine since it was booted. " \

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -192,12 +192,13 @@ def machine_repair(original: Machine, removed_chips: Iterable[XY] = ()):
                 chip.x, chip.y, chip.parent_link)
             if not original.is_chip_at(parent_x, parent_y):
                 ethernet = original[chip.nearest_ethernet_x,
-                                    chip.nearest_ethernet_y].ip_address
+                                    chip.nearest_ethernet_y]
                 msg = f"The source: {Chip} will fail to receive signals " \
                       f"because its parent {parent_x}:{parent_y} in the " \
                       f"signal tree has disappeared from the machine since " \
                       f"it was booted. This occurred on board with " \
-                      f"ip address {ethernet} Please report this to " \
+                      f"ip address {ethernet.ip_address} " \
+                      f"Please report this to " \
                       f"spinnakerusers@googlegroups.com \n\n"
                 if repair_machine:
                     dead_chips.add((chip.x, chip.y))

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -14,7 +14,7 @@
 
 from collections import defaultdict
 import logging
-from typing import Collection, Iterable, Optional, Set, Tuple
+from typing import Collection, Iterable, Set, Tuple
 from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY
@@ -191,17 +191,14 @@ def machine_repair(original: Machine, removed_chips: Iterable[XY] = ()):
             parent_x, parent_y = original.xy_over_link(
                 chip.x, chip.y, chip.parent_link)
             if not original.is_chip_at(parent_x, parent_y):
-                ethernet_chip = original[
-                    chip.nearest_ethernet_x, chip.nearest_ethernet_y]
-                return f"The {source: Chip} will fail to receive signals " \
-                       f"because its parent {parent_x}:{parent_y} in the " \
-                       f"signal tree has disappeared from the machine since " \
-                       f"it was booted. This occurred on board with " \
-                       f"ip address {address} Please report this to " \
-                       f"spinnakerusers@googlegroups.com \n\n"
-
-                msg = __chip_dead_parent_msg(
-                    chip, parent_x, parent_y, ethernet_chip.ip_address)
+                ethernet = original[chip.nearest_ethernet_x,
+                                    chip.nearest_ethernet_y].ip_address
+                msg = f"The source: {Chip} will fail to receive signals " \
+                      f"because its parent {parent_x}:{parent_y} in the " \
+                      f"signal tree has disappeared from the machine since " \
+                      f"it was booted. This occurred on board with " \
+                      f"ip address {ethernet} Please report this to " \
+                      f"spinnakerusers@googlegroups.com \n\n"
                 if repair_machine:
                     dead_chips.add((chip.x, chip.y))
                     logger.warning(msg)

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -28,23 +28,23 @@ BAD_MSG = (
     "Your machine has {} at {} on board {} which will cause algorithms to "
     "fail. Please report this to spinnakerusers@googlegroups.com \n\n")
 ONE_LINK_SAME_BOARD_MSG = (
-    "Link {} from global chip id {}:{} to global chip id {}:{} does not "
+    "Link {} from {} to {} does not "
     "exist, but the opposite does. Both chips live on the same board under "
     "ip address {} and are local chip ids {}:{} and {}:{}. "
     "Please report this to spinnakerusers@googlegroups.com \n\n")
 ONE_LINK_DIFFERENT_BOARDS_MSG = (
-    "Link {} from global chip id {}:{} to global chip id {}:{} does not "
+    "Link {} from {} to {} does not "
     "exist, but the opposite does. The chips live on different boards. "
     "chip {}:{} resides on board with ip address {} with local id {}:{} and "
     "chip {}:{} resides on board with ip address {} with local id {}:{}. "
     "Please report this to spinnakerusers@googlegroups.com \n\n")
 ONE_LINK_DEAD_CHIP = (
-    "Link {} from global dead chip id {}:{} to global chip id {}:{} does not "
+    "Link {} from {} to {} does not "
     "exist, but the opposite does. chip {}:{} resides on board with ip "
     "address {} but as chip {}:{} is dead, we cannot report its ip address. "
     "Please report this to spinnakerusers@googlegroups.com \n\n")
 CHIP_REMOVED_BY_DEAD_PARENT = (
-    "The chip {}:{} will fail to receive signals because its parent {}:{} in"
+    "The {} will fail to receive signals because its parent {}:{} in"
     " the signal tree has disappeared from the machine since it was booted. "
     "This occurred on board with ip address {} Please report this to "
     "spinnakerusers@googlegroups.com \n\n")
@@ -101,6 +101,7 @@ def _machine_ignore(
     return new_machine
 
 
+
 def _generate_uni_direction_link_error(
         dest_x: int, dest_y: int, src_x: int, src_y: int, back: int,
         original: Machine) -> str:
@@ -113,7 +114,7 @@ def _generate_uni_direction_link_error(
     # if the dest chip is dead. Only report src chip ip address.
     if dest_chip is None:
         return ONE_LINK_DEAD_CHIP.format(
-            back, dest_x, dest_y, src_x, src_y, src_x, src_y, src_ethernet,
+            back, dest_chip, src_chip, src_x, src_y, src_ethernet,
             dest_x, dest_y)
 
     # got working chips, so get the separate ethernet's
@@ -128,12 +129,12 @@ def _generate_uni_direction_link_error(
     # board.
     if src_ethernet == dest_ethernet:
         return ONE_LINK_SAME_BOARD_MSG.format(
-            back, dest_x, dest_y, src_x, src_y, src_ethernet,
+            back, dest_chip, src_chip, src_ethernet,
             local_dest_chip_x, local_dest_chip_y, local_src_chip_x,
             local_src_chip_y)
     else:
         return ONE_LINK_DIFFERENT_BOARDS_MSG.format(
-            back, dest_x, dest_y, src_x, src_y, dest_x, dest_y, dest_ethernet,
+            back, dest_chip, src_chip, dest_x, dest_y, dest_ethernet,
             local_dest_chip_x, local_dest_chip_y, src_x, src_y, src_ethernet,
             local_src_chip_x, local_src_chip_y)
 
@@ -210,7 +211,7 @@ def machine_repair(original: Machine, removed_chips: Iterable[XY] = ()):
                 ethernet_chip = original[
                     chip.nearest_ethernet_x, chip.nearest_ethernet_y]
                 msg = CHIP_REMOVED_BY_DEAD_PARENT.format(
-                    chip.x, chip.y, parent_x, parent_y,
+                    chip, parent_x, parent_y,
                     ethernet_chip.ip_address)
                 if repair_machine:
                     dead_chips.add((chip.x, chip.y))

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -14,7 +14,7 @@
 
 from collections import defaultdict
 import logging
-from typing import Collection, Iterable, Set, Tuple
+from typing import Collection, Iterable, Optional, Set, Tuple
 from spinn_utilities.config_holder import get_config_bool
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY
@@ -200,14 +200,14 @@ def machine_repair(original: Machine, removed_chips: Iterable[XY] = ()):
     return machine_repair(new_machine)
 
 
-def __bad_message(issue: str, xp: XY, address: str) -> str:
+def __bad_message(issue: str, xp: XY, address: Optional[str]) -> str:
     return f"Your machine has {issue} at {xp} on board {address} " \
            f"which will cause algorithms to fail. " \
            f"Please report this to spinnakerusers@googlegroups.com \n\n"
 
 
 def __one_link_same_board_msg(
-        link: int, source: Chip, target: Chip, address: str,
+        link: int, source: Chip, target: Chip, address: Optional[str],
         source_x: int, source_y: int, target_x: int, target_y: int) -> str:
     return f"Link {link} from {source} to {target} does not exist, " \
            f"but the opposite does. Both chips live on the same board under " \
@@ -218,8 +218,8 @@ def __one_link_same_board_msg(
 
 def one_link_different_boards_msg(
         link: int, source: Chip, target: Chip, source_x: int, source_y: int,
-        source_address: str, target_x: int, target_y: int,
-        target_address: str) -> str:
+        source_address: Optional[str], target_x: int, target_y: int,
+        target_address: Optional[str]) -> str:
     return f"Link {link} from {source} to {target} does not exist, " \
            f"but the opposite does. The chips live on different boards. " \
            f"chip {source.x}:{source.y} resides on board with ip address " \
@@ -230,15 +230,15 @@ def one_link_different_boards_msg(
 
 
 def __link_dead_chip(link: int, source: Chip, target_x: int, target_y: int,
-                     address: str) -> str:
+                     address: Optional[str]) -> str:
     return f"Link {link} from {source} to {target_x}:{target_y} " \
            f"points to a dead chip. Chip {source.x}:" \
            f"{source.y} resides on board with ip address {address}. " \
            f"Please report this to spinnakerusers@googlegroups.com \n\n"
 
 
-def __chip_dead_parent_msg(
-        source: Chip, parent_x: int, parent_y: int, address: str) -> str:
+def __chip_dead_parent_msg(source: Chip, parent_x: int, parent_y: int,
+                           address: Optional[str]) -> str:
     return f"The {source: Chip} will fail to receive signals because its " \
            f"parent {parent_x}:{parent_y} in the signal tree has " \
            f"disappeared from the machine since it was booted. " \

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -56,38 +56,9 @@ class TestingChip(unittest.TestCase):
             self.assertIsNone(new_chip[42])
         print(new_chip.__repr__())
         self.assertEqual(
-            new_chip.__repr__(),
-            "[Chip: x=0, y=1, sdram=0 MB, ip_address=192.162.240.253, "
-            "router=[Router: "
-            "available_entries=1024, links=["
-            "[Link: source_x=0, source_y=0, source_link_id=0, "
-            "destination_x=1, destination_y=1], "
-            "[Link: source_x=0, source_y=1, source_link_id=1, "
-            "destination_x=1, destination_y=0], "
-            "[Link: source_x=1, source_y=1, source_link_id=2, "
-            "destination_x=0, destination_y=0], "
-            "[Link: source_x=1, source_y=0, source_link_id=3, "
-            "destination_x=0, destination_y=1]"
-            "]], processors=["
-            "[CPU: id=0, clock_speed=200 MHz, monitor=True], "
-            "[CPU: id=1, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=2, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=3, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=4, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=5, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=6, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=7, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=8, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=9, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=10, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=11, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=12, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=13, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=14, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=15, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=16, clock_speed=200 MHz, monitor=False], "
-            "[CPU: id=17, clock_speed=200 MHz, monitor=False]], "
-            "nearest_ethernet=0:0]")
+            "[Chip: x=0, y=1, ip_address=192.162.240.253 "
+            "n_cores=18, mon=None]",
+            new_chip.__repr__(),)
         self.assertEqual(new_chip.tag_ids, OrderedSet([1, 2, 3, 4, 5, 6, 7]))
         self.assertEqual(
             [p[0] for p in new_chip],


### PR DESCRIPTION
This PR.
1. Simplifies the String representation of a Chip but adds the the phyiscal monitor core.
2. Fixes tests due to 1
3. Uses the new string for the bad machine warnings
-including inlining the messages to make the code easier to read.
- fixes https://github.com/SpiNNakerManchester/SpiNNMachine/issues/228