### PR TITLE
Test that overides type check work in Github actions and Jenkins

### DIFF
--- a/spinn_machine/horizontal_wrap_machine.py
+++ b/spinn_machine/horizontal_wrap_machine.py
@@ -26,7 +26,7 @@ class HorizontalWrapMachine(Machine):
 
     @overrides(Machine.get_xys_by_ethernet)
     def get_xys_by_ethernet(
-            self, ethernet_x: int, ethernet_y: int) -> Iterable[XY]:
+            self, ethernet_x: int, ethernet_y) -> Iterable[XY]:
         for (x, y) in self._chip_core_map:
             chip_x = (x + ethernet_x) % self._width
             chip_y = (y + ethernet_y)


### PR DESCRIPTION
Do not merge. This is an intentional failure!

In Actions you get:
import_all and possibly other unittest failings

In Jenkins you get
source ${WORKSPACE}/pyenv/bin/activate && python -m spynnaker.pyNN.setup_pynn
failing
as it does the imports and that checks overides

Note:
this is because bot set the Environment variable "CI" to True
