### PR TITLE
Chip as xy

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import (
-    Collection, Dict, Iterable, Iterator, Optional, Tuple, Union)
+from typing import (Collection, Dict, Iterable, Iterator, Optional)
 from spinn_utilities.ordered_set import OrderedSet
 from spinn_machine.data import MachineDataView
 from .processor import Processor

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -335,7 +335,7 @@ class Chip(object):
     def __repr__(self) -> str:
         return self.__str__()
 
-    def __eq__(self, other: Union["Chip", Tuple[int, int]]) -> bool:
+    def __eq__(self, other):
         """
         To allow a Chip and an X,Y tuple to be used interchangeably
 

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -322,7 +322,6 @@ class Chip(object):
             return self._y
         raise IndexError(xy_id)
 
-
     def __str__(self) -> str:
         if self._ip_address:
             ip_info = f"ip_address={self.ip_address} "

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -22,6 +22,7 @@ from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_utilities.typing.coords import XY
 from spinn_machine.data import MachineDataView
 from spinn_machine.link_data_objects import FPGALinkData, SpinnakerLinkData
+from .types import AS_XY
 from .exceptions import (
     SpinnMachineAlreadyExistsException, SpinnMachineException)
 
@@ -110,7 +111,7 @@ class Machine(object, metaclass=AbstractBase):
         self._boot_ethernet_address: Optional[str] = None
 
         # The dictionary of chips
-        self._chips: Dict[XY, Chip] = dict()
+        self._chips: Dict[AS_XY, Chip] = dict()
 
         self._origin = origin
 
@@ -566,12 +567,11 @@ class Machine(object, metaclass=AbstractBase):
         :raise SpinnMachineAlreadyExistsException:
             If a chip with the same x and y coordinates already exists
         """
-        chip_id = (chip.x, chip.y)
-        if chip_id in self._chips:
+        if chip in self._chips:
             raise SpinnMachineAlreadyExistsException(
                 "chip", f"{chip.x}, {chip.y}")
 
-        self._chips[chip_id] = chip
+        self._chips[chip] = chip
 
         # keep some stats about the
         self._n_cores_counter[chip.n_processors] += 1
@@ -607,7 +607,7 @@ class Machine(object, metaclass=AbstractBase):
         return iter(self._chips.values())
 
     @property
-    def chip_coordinates(self) -> Iterator[XY]:
+    def chip_coordinates(self) -> Iterator[AS_XY]:
         """
         An iterable of chip coordinates in the machine.
 
@@ -615,7 +615,7 @@ class Machine(object, metaclass=AbstractBase):
         """
         return iter(self._chips.keys())
 
-    def __iter__(self) -> Iterator[Tuple[XY, Chip]]:
+    def __iter__(self) -> Iterator[Tuple[AS_XY, Chip]]:
         """
         Get an iterable of the chip coordinates and chips.
 
@@ -684,7 +684,7 @@ class Machine(object, metaclass=AbstractBase):
         """
         return (x, y) in self._chips and self._chips[x, y].router.is_link(link)
 
-    def __contains__(self, x_y_tuple: XY):
+    def __contains__(self, x_y_tuple: AS_XY):
         """
         Determine if a chip exists at the given coordinates.
 
@@ -746,7 +746,7 @@ class Machine(object, metaclass=AbstractBase):
 
     def get_spinnaker_link_with_id(
             self, spinnaker_link_id: int, board_address: Optional[str] = None,
-            chip_coords: Optional[XY] = None) -> SpinnakerLinkData:
+            chip_coords: Optional[AS_XY] = None) -> SpinnakerLinkData:
         """
         Get a SpiNNaker link with a given ID.
 
@@ -1184,7 +1184,7 @@ class Machine(object, metaclass=AbstractBase):
         """
         removable_coords: List[XY] = list()
         for chip in self._chips.values():
-            x, y = chip.x, chip.y
+            x, y = chip
             nearest_ethernet_x = chip.nearest_ethernet_x
             nearest_ethernet_y = chip.nearest_ethernet_y
             # Go through all the chips that surround this one

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
     from .chip import Chip
 
 logger = logging.getLogger(__name__)
-_SpinLinkKey: TypeAlias = Tuple[Union[str, XY], int]
-_FpgaLinkKey: TypeAlias = Tuple[Union[str, XY], int, int]
+_SpinLinkKey: TypeAlias = Tuple[Union[str, XY, "Chip"], int]
+_FpgaLinkKey: TypeAlias = Tuple[Union[str, XY, "Chip"], int, int]
 
 
 class Machine(object, metaclass=AbstractBase):

--- a/spinn_machine/types.py
+++ b/spinn_machine/types.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Types for coordinates.
+"""
+
+from typing import Tuple, Union
+from typing_extensions import TypeAlias
+
+from spinn_machine.chip import Chip
+
+#: The type of X,Y pairs or an Object that acts like an X, y pair
+AS_XY: TypeAlias = Union[Tuple[int, int], Chip]

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -52,25 +52,14 @@ class TestingChip(unittest.TestCase):
         self.assertEqual(new_chip.sdram, self._sdram)
         self.assertEqual(new_chip.router, self._router)
         self.assertEqual(new_chip.n_user_processors, self.n_processors - 1)
-        with self.assertRaises(KeyError):
-            self.assertIsNone(new_chip[42])
         print(new_chip.__repr__())
         self.assertEqual(
             "[Chip: x=0, y=1, ip_address=192.162.240.253 "
             "n_cores=18, mon=None]",
             new_chip.__repr__(),)
         self.assertEqual(new_chip.tag_ids, OrderedSet([1, 2, 3, 4, 5, 6, 7]))
-        self.assertEqual(
-            [p[0] for p in new_chip],
-            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
-        self.assertEqual(
-            [p[1].is_monitor for p in new_chip],
-            [True, False, False, False, False, False, False, False, False,
-             False, False, False, False, False, False, False, False, False])
         self.assertTrue(new_chip.is_processor_with_id(3))
         self.assertEqual(5, new_chip.get_processor_with_id(5).processor_id)
-        self.assertEqual(6, new_chip[6].processor_id)
-        self.assertTrue(7 in new_chip)
         self.assertIsNone(new_chip.get_processor_with_id(-1))
 
     def test_get_first_none_monitor_processor(self):
@@ -82,19 +71,6 @@ class TestingChip(unittest.TestCase):
                                      self._router, self._sdram, self._ip)
         non_monitor = new_chip.get_first_none_monitor_processor()
         self.assertFalse(non_monitor.is_monitor)
-
-    def test_getitem_and_contains(self):
-        """ test the __getitem__ an __contains__ methods
-
-        NOTE: Not sure if method being tested is required.
-        """
-        new_chip = self._create_chip(self._x, self._y, self.n_processors,
-                                     self._router, self._sdram, self._ip)
-        new_chip[3]
-        with self.assertRaises(KeyError):
-            new_chip[self.n_processors]
-        self.assertTrue(3 in new_chip)
-        self.assertFalse(self.n_processors in new_chip)
 
     def test_0_down(self):
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This allows a Chip and an XY tuple to be used interchangeably.

So far only a few of the many dicts are converted.

Fixes https://github.com/SpiNNakerManchester/SpiNNMachine/issues/230
