### PR TITLE
only expose processor virtual ids

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -188,26 +188,6 @@ class Chip(object):
         return self._y
 
     @property
-    def processors(self) -> Iterator[Processor]:
-        """
-        An iterable of available all processors.
-
-        Deprecated: There are many more efficient methods instead.
-        - all_processor_ids
-        - n_processors
-        - n_user_processors
-        - user_processors
-        - user_processors_ids
-        - n_monitor_processors
-        - monitor_processors
-        - monitor_processors_ids
-
-        :rtype: iterable(Processor)
-        """
-        yield from self._monitor_processors.values()
-        yield from self._user_processors.values()
-
-    @property
     def all_processor_ids(self) -> Iterator[int]:
         """
         An iterable of id's of all available processors
@@ -227,15 +207,6 @@ class Chip(object):
         return len(self._monitor_processors) + len(self._user_processors)
 
     @property
-    def user_processors(self) -> Iterator[Processor]:
-        """
-        An iterable of available user processors.
-
-        :rtype: iterable(Processor)
-        """
-        yield from self._user_processors.values()
-
-    @property
     def user_processors_ids(self) -> Iterator[int]:
         """
         An iterable of available user processors.
@@ -252,15 +223,6 @@ class Chip(object):
         :rtype: int
         """
         return len(self._user_processors)
-
-    @property
-    def monitor_processors(self) -> Iterator[Processor]:
-        """
-        An iterable of available monitor processors.
-
-        :rtype: iterable(Processor)
-        """
-        return self._monitor_processors.values()
 
     @property
     def monitor_processors_ids(self) -> Iterator[int]:

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -113,17 +113,13 @@ class TestingChip(unittest.TestCase):
     def test_processors(self):
         new_chip = self._create_chip(self._x, self._y, self.n_processors,
                                      self._router, self._sdram, self._ip)
-        all_p = set()
-        for id in new_chip.all_processor_ids:
-            all_p.add(new_chip[id])
+        all_p = set(new_chip.all_processor_ids)
         self.assertEqual(len(all_p), new_chip.n_processors)
-        users = set(new_chip.user_processors)
+        users = set(new_chip.user_processors_ids)
         self.assertEqual(len(users), new_chip.n_user_processors)
-        self.assertEqual(len(users), len(set(new_chip.user_processors_ids)))
-        monitors = set(new_chip.monitor_processors)
+        monitors = set(new_chip.monitor_processors_ids)
         self.assertEqual(users.union(monitors), all_p)
-        self.assertEqual(len(monitors),
-                         len(set(new_chip.monitor_processors_ids)))
+        self.assertEqual(len(monitors), new_chip.n_monitor_processors)
 
 
 if __name__ == '__main__':

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -178,8 +178,8 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(n_cpus, _chip.n_processors)
         self.assertEqual(n_cpus - 1, _chip.n_user_processors)
         self.assertEqual(1, _chip.n_monitor_processors)
-        self.assertEqual(n_cpus - 1, len(list(_chip.user_processors)))
-        self.assertEqual(1, len(list(_chip.monitor_processors)))
+        self.assertEqual(n_cpus - 1, len(list(_chip.user_processors_ids)))
+        self.assertEqual(1, len(list(_chip.monitor_processors_ids)))
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 4 * n_cpus)
 


### PR DESCRIPTION
fixes https://github.com/SpiNNakerManchester/SpiNNMachine/issues/242

removes all methods that expose the Processor class

Todo:
Move     CLOCK_SPEED = 200 * 1000 * 1000 and    DTCM_AVAILABLE = 2 ** 16 to version
remove the Processor class
