### PR TITLE
processor renaming

### DIFF
--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -42,7 +42,7 @@ class Chip(object):
     __slots__ = (
         "_x", "_y", "_router", "_sdram", "_ip_address",
         "_tag_ids", "_nearest_ethernet_x", "_nearest_ethernet_y",
-        "_user_processors", "_scamp_processors", "_parent_link",
+        "_placable_processors", "_scamp_processors", "_parent_link",
         "_v_to_p_map"
     )
 
@@ -89,7 +89,7 @@ class Chip(object):
         self._x = x
         self._y = y
         self._scamp_processors = self.__generate_scamp()
-        self._user_processors = self.__generate_processors(
+        self._placable_processors = self.__generate_processors(
             n_processors, down_cores)
         self._router = router
         self._sdram = sdram
@@ -150,7 +150,7 @@ class Chip(object):
         :return: Whether the processor with the given ID exists
         :rtype: bool
         """
-        if processor_id in self._user_processors:
+        if processor_id in self._placable_processors:
             return True
         return processor_id in self._scamp_processors
 
@@ -165,8 +165,8 @@ class Chip(object):
             or ``None`` if no such processor
         :rtype: Processor or None
         """
-        if processor_id in self._user_processors:
-            return self._user_processors[processor_id]
+        if processor_id in self._placable_processors:
+            return self._placable_processors[processor_id]
         return self._scamp_processors.get(processor_id)
 
     @property
@@ -205,7 +205,7 @@ class Chip(object):
         :rtype: iterable(Processor)
         """
         yield from self._scamp_processors.values()
-        yield from self._user_processors.values()
+        yield from self._placable_processors.values()
 
     @property
     def all_processor_ids(self) -> Iterator[int]:
@@ -215,7 +215,7 @@ class Chip(object):
         :rtype: iterable(int)
         """
         yield from self._scamp_processors.keys()
-        yield from self._user_processors.keys()
+        yield from self._placable_processors.keys()
 
     @property
     def n_processors(self) -> int:
@@ -224,34 +224,34 @@ class Chip(object):
 
         :rtype: int
         """
-        return len(self._scamp_processors) + len(self._user_processors)
+        return len(self._scamp_processors) + len(self._placable_processors)
 
     @property
-    def user_processors(self) -> Iterator[Processor]:
+    def placeable_processors(self) -> Iterator[Processor]:
         """
-        An iterable of available user processors.
+        An iterable of available placable/ none scamp processors.
 
         :rtype: iterable(Processor)
         """
-        yield from self._user_processors.values()
+        yield from self._placable_processors.values()
 
     @property
-    def user_processors_ids(self) -> Iterator[int]:
+    def placable_processors_ids(self) -> Iterator[int]:
         """
-        An iterable of available user processors.
+        An iterable of available placable/ non scamp processor ids.
 
         :rtype: iterable(Processor)
         """
-        yield from self._user_processors
+        yield from self._placable_processors
 
     @property
-    def n_user_processors(self) -> int:
+    def n_placable_processors(self) -> int:
         """
-        The total number of processors that are not used by scamp.
+        The total number of processors that are placable / not used by scamp.
 
         :rtype: int
         """
-        return len(self._user_processors)
+        return len(self._placable_processors)
 
     @property
     def scamp_processors(self) -> Iterator[Processor]:
@@ -342,7 +342,7 @@ class Chip(object):
         :rtype: Processor
         ;raises StopIteration: If there is no user processor
         """
-        return next(iter(self._user_processors.values()))
+        return next(iter(self._placable_processors.values()))
 
     @property
     def parent_link(self) -> Optional[int]:
@@ -390,7 +390,7 @@ class Chip(object):
         :rtype: iterable(tuple(int,Processor))
         """
         yield from self._scamp_processors.items()
-        yield from self._user_processors.items()
+        yield from self._placable_processors.items()
 
     def __len__(self) -> int:
         """
@@ -399,11 +399,11 @@ class Chip(object):
         :return: The number of items in the underlying iterator.
         :rtype: int
         """
-        return len(self._scamp_processors) + len(self._user_processors)
+        return len(self._scamp_processors) + len(self._placable_processors)
 
     def __getitem__(self, processor_id: int) -> Processor:
-        if processor_id in self._user_processors:
-            return self._user_processors[processor_id]
+        if processor_id in self._placable_processors:
+            return self._placable_processors[processor_id]
         if processor_id in self._scamp_processors:
             return self._scamp_processors[processor_id]
         # Note difference from get_processor_with_id(); this is to conform to

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -272,7 +272,7 @@ class Chip(object):
         yield from self._scamp_processors
 
     @property
-    def n_monitor_processors(self) -> int:
+    def n_scamp_processors(self) -> int:
         """
         The total number of processors that are used by scamp.
 

--- a/spinn_machine/chip.py
+++ b/spinn_machine/chip.py
@@ -115,14 +115,14 @@ class Chip(object):
         if standard_monitor_processors is None:
             standard_monitor_processors = dict()
             for i in range(
-                    MachineDataView.get_machine_version().n_non_user_cores):
+                    MachineDataView.get_machine_version().n_scamp_cores):
                 standard_monitor_processors[i] = Processor.factory(i, True)
         return standard_monitor_processors
 
     def __generate_processors(
             self, n_processors: int,
             down_cores: Optional[Collection[int]]) -> Dict[int, Processor]:
-        n_monitors = MachineDataView.get_machine_version().n_non_user_cores
+        n_monitors = MachineDataView.get_machine_version().n_scamp_cores
         if down_cores is None:
             if n_processors not in standard_processors:
                 processors = dict()

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -204,9 +204,9 @@ def _describe_chip(chip: Chip, standard, ethernet) -> JsonArray:
     if chip.ip_address is not None:
         details['ipAddress'] = chip.ip_address
         # Write the Resources ONLY if different from the e_values
-        if (chip.n_processors - chip.n_user_processors) != ethernet.monitors:
+        if (chip.n_processors - chip.n_placable_processors) != ethernet.monitors:
             exceptions["monitors"] = \
-                chip.n_processors - chip.n_user_processors
+                chip.n_processors - chip.n_placable_processors
         if router_entries != ethernet.router_entries:
             exceptions["routerEntries"] = router_entries
         if chip.sdram != ethernet.sdram:
@@ -215,9 +215,9 @@ def _describe_chip(chip: Chip, standard, ethernet) -> JsonArray:
             exceptions["tags"] = tags
     else:
         # Write the Resources ONLY if different from the s_values
-        if (chip.n_processors - chip.n_user_processors) != standard.monitors:
+        if (chip.n_processors - chip.n_placable_processors) != standard.monitors:
             exceptions["monitors"] = \
-                chip.n_processors - chip.n_user_processors
+                chip.n_processors - chip.n_placable_processors
         if router_entries != standard.router_entries:
             exceptions["routerEntries"] = router_entries
         if chip.sdram != standard.sdram:
@@ -243,7 +243,7 @@ def to_json() -> JsonObject:
     for chip in machine.chips:
         if chip.ip_address is None:
             std = _Desc(
-                monitors=chip.n_processors - chip.n_user_processors,
+                monitors=chip.n_processors - chip.n_placable_processors,
                 router_entries=_int_value(
                     chip.router.n_available_multicast_entries),
                 sdram=chip.sdram,
@@ -255,7 +255,7 @@ def to_json() -> JsonObject:
     # find the nth values to use for Ethernet chips
     chip = machine.boot_chip
     eth = _Desc(
-        monitors=chip.n_processors - chip.n_user_processors,
+        monitors=chip.n_processors - chip.n_placable_processors,
         router_entries=_int_value(
             chip.router.n_available_multicast_entries),
         sdram=chip.sdram,

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -204,9 +204,8 @@ def _describe_chip(chip: Chip, standard, ethernet) -> JsonArray:
     if chip.ip_address is not None:
         details['ipAddress'] = chip.ip_address
         # Write the Resources ONLY if different from the e_values
-        if (chip.n_processors - chip.n_placable_processors) != ethernet.monitors:
-            exceptions["monitors"] = \
-                chip.n_processors - chip.n_placable_processors
+        if (chip.n_scamp_processors) != ethernet.monitors:
+            exceptions["monitors"] = chip.n_scamp_processors
         if router_entries != ethernet.router_entries:
             exceptions["routerEntries"] = router_entries
         if chip.sdram != ethernet.sdram:
@@ -215,9 +214,8 @@ def _describe_chip(chip: Chip, standard, ethernet) -> JsonArray:
             exceptions["tags"] = tags
     else:
         # Write the Resources ONLY if different from the s_values
-        if (chip.n_processors - chip.n_placable_processors) != standard.monitors:
-            exceptions["monitors"] = \
-                chip.n_processors - chip.n_placable_processors
+        if (chip.n_scamp_processors) != standard.monitors:
+            exceptions["monitors"] = chip.n_scamp_processors
         if router_entries != standard.router_entries:
             exceptions["routerEntries"] = router_entries
         if chip.sdram != standard.sdram:

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -1084,7 +1084,7 @@ class Machine(object, metaclass=AbstractBase):
 
         :rtype: int
         """
-        return sum(chip.n_user_processors for chip in self.chips)
+        return sum(chip.n_placable_processors for chip in self.chips)
 
     @property
     def total_cores(self) -> int:

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -145,9 +145,9 @@ class AbstractVersion(object, metaclass=AbstractBase):
 
     @property
     @abstractmethod
-    def n_non_user_cores(self) -> int:
+    def n_scamp_cores(self) -> int:
         """
-        The number of system cores per chip.
+        The number of scamp cores per chip.
 
         :rtype: int
         """

--- a/spinn_machine/version/version_spin1.py
+++ b/spinn_machine/version/version_spin1.py
@@ -29,8 +29,8 @@ class VersionSpin1(AbstractVersion, metaclass=AbstractBase):
         super().__init__(max_cores_per_chip=18, max_sdram_per_chip=123469792)
 
     @property
-    @overrides(AbstractVersion.n_non_user_cores)
-    def n_non_user_cores(self) -> int:
+    @overrides(AbstractVersion.n_scamp_cores)
+    def n_scamp_cores(self) -> int:
         return 1
 
     @property

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -53,7 +53,7 @@ class TestingChip(unittest.TestCase):
         self.assertEqual(new_chip.ip_address, self._ip)
         self.assertEqual(new_chip.sdram, self._sdram)
         self.assertEqual(new_chip.router, self._router)
-        self.assertEqual(new_chip.n_user_processors, self.n_processors - 1)
+        self.assertEqual(new_chip.n_placable_processors, self.n_processors - 1)
         with self.assertRaises(KeyError):
             self.assertIsNone(new_chip[42])
         print(new_chip.__repr__())
@@ -117,9 +117,9 @@ class TestingChip(unittest.TestCase):
         for id in new_chip.all_processor_ids:
             all_p.add(new_chip[id])
         self.assertEqual(len(all_p), new_chip.n_processors)
-        users = set(new_chip.user_processors)
-        self.assertEqual(len(users), new_chip.n_user_processors)
-        self.assertEqual(len(users), len(set(new_chip.user_processors_ids)))
+        users = set(new_chip.placeable_processors)
+        self.assertEqual(len(users), new_chip.n_placable_processors)
+        self.assertEqual(len(users), len(set(new_chip.placable_processors_ids)))
         monitors = set(new_chip.scamp_processors)
         self.assertEqual(users.union(monitors), all_p)
         self.assertEqual(len(monitors),

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -119,7 +119,8 @@ class TestingChip(unittest.TestCase):
         self.assertEqual(len(all_p), new_chip.n_processors)
         users = set(new_chip.placeable_processors)
         self.assertEqual(len(users), new_chip.n_placable_processors)
-        self.assertEqual(len(users), len(set(new_chip.placable_processors_ids)))
+        self.assertEqual(len(users),
+                         len(set(new_chip.placable_processors_ids)))
         monitors = set(new_chip.scamp_processors)
         self.assertEqual(users.union(monitors), all_p)
         self.assertEqual(len(monitors),

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -120,10 +120,10 @@ class TestingChip(unittest.TestCase):
         users = set(new_chip.user_processors)
         self.assertEqual(len(users), new_chip.n_user_processors)
         self.assertEqual(len(users), len(set(new_chip.user_processors_ids)))
-        monitors = set(new_chip.monitor_processors)
+        monitors = set(new_chip.scamp_processors)
         self.assertEqual(users.union(monitors), all_p)
         self.assertEqual(len(monitors),
-                         len(set(new_chip.monitor_processors_ids)))
+                         len(set(new_chip.scamp_processors_ids)))
 
 
 if __name__ == '__main__':

--- a/unittests/test_json_machine.py
+++ b/unittests/test_json_machine.py
@@ -63,11 +63,11 @@ class TestJsonMachine(unittest.TestCase):
         MachineDataWriter.mock().set_machine(vm)
         chip02 = vm[0, 2]
         # Hack in an extra monitor
-        users = dict(chip02._user_processors)
+        users = dict(chip02._placable_processors)
         monitors = dict(chip02._scamp_processors)
         monitors[1] = users.pop(1)
         chip02._scamp_processors = monitors
-        chip02._user_processors = users
+        chip02._placable_processors = users
         jpath = mktemp("json")
         # Should still be able to write json even with more than one monitor
         to_json_path(jpath)

--- a/unittests/test_json_machine.py
+++ b/unittests/test_json_machine.py
@@ -64,9 +64,9 @@ class TestJsonMachine(unittest.TestCase):
         chip02 = vm[0, 2]
         # Hack in an extra monitor
         users = dict(chip02._user_processors)
-        monitors = dict(chip02._monitor_processors)
+        monitors = dict(chip02._scamp_processors)
         monitors[1] = users.pop(1)
-        chip02._monitor_processors = monitors
+        chip02._scamp_processors = monitors
         chip02._user_processors = users
         jpath = mktemp("json")
         # Should still be able to write json even with more than one monitor

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -390,8 +390,8 @@ class SpinnMachineTestCase(unittest.TestCase):
         machine = virtual_machine(8, 8)
         # Hack to get n_processors return a low number
         chip01 = machine.get_chip_at(0, 1)
-        chip01._user_processors = dict(
-            list(chip01._user_processors.items())[:2])
+        chip01._placable_processors = dict(
+            list(chip01._placable_processors.items())[:2])
         with self.assertRaises(SpinnMachineException):
             machine.validate()
 

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -177,7 +177,7 @@ class TestVirtualMachine(unittest.TestCase):
         _chip = vm[1, 1]
         self.assertEqual(n_cpus, _chip.n_processors)
         self.assertEqual(n_cpus - 1, _chip.n_placable_processors)
-        self.assertEqual(1, _chip.n_monitor_processors)
+        self.assertEqual(1, _chip.n_scamp_processors)
         self.assertEqual(n_cpus - 1, len(list(_chip.placeable_processors)))
         self.assertEqual(1, len(list(_chip.scamp_processors)))
         count = sum(_chip.n_processors for _chip in vm.chips)

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -179,7 +179,7 @@ class TestVirtualMachine(unittest.TestCase):
         self.assertEqual(n_cpus - 1, _chip.n_user_processors)
         self.assertEqual(1, _chip.n_monitor_processors)
         self.assertEqual(n_cpus - 1, len(list(_chip.user_processors)))
-        self.assertEqual(1, len(list(_chip.monitor_processors)))
+        self.assertEqual(1, len(list(_chip.scamp_processors)))
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 4 * n_cpus)
 

--- a/unittests/test_virtual_machine.py
+++ b/unittests/test_virtual_machine.py
@@ -176,9 +176,9 @@ class TestVirtualMachine(unittest.TestCase):
         vm = virtual_machine(2, 2, validate=True)
         _chip = vm[1, 1]
         self.assertEqual(n_cpus, _chip.n_processors)
-        self.assertEqual(n_cpus - 1, _chip.n_user_processors)
+        self.assertEqual(n_cpus - 1, _chip.n_placable_processors)
         self.assertEqual(1, _chip.n_monitor_processors)
-        self.assertEqual(n_cpus - 1, len(list(_chip.user_processors)))
+        self.assertEqual(n_cpus - 1, len(list(_chip.placeable_processors)))
         self.assertEqual(1, len(list(_chip.scamp_processors)))
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 4 * n_cpus)

--- a/unittests/version/test_version3.py
+++ b/unittests/version/test_version3.py
@@ -33,7 +33,7 @@ class TestVersion3(unittest.TestCase):
         version = Version3()
         self.assertEqual(18, version.max_cores_per_chip)
         self.assertEqual(123469792, version.max_sdram_per_chip)
-        self.assertEqual(1, version.n_non_user_cores)
+        self.assertEqual(1, version.n_scamp_cores)
         self.assertEqual("Spin1 4 Chip", version.name)
         self.assertEqual(3, version.number)
         self.assertEqual((2, 2), version.board_shape)

--- a/unittests/version/test_version5.py
+++ b/unittests/version/test_version5.py
@@ -36,7 +36,7 @@ class TestVersion5(unittest.TestCase):
         version = Version5()
         self.assertEqual(18, version.max_cores_per_chip)
         self.assertEqual(123469792, version.max_sdram_per_chip)
-        self.assertEqual(1, version.n_non_user_cores)
+        self.assertEqual(1, version.n_scamp_cores)
         self.assertEqual("Spin1 48 Chip", version.name)
         self.assertEqual(5, version.number)
         self.assertEqual((8, 8), version.board_shape)


### PR DESCRIPTION
The names we have for processor types are reused with different meanings.

In Chip and processor "monitor" meant the scamp processor

Elsewhere "monitor" referred to the system cores.

These PRs suggest.

Rename Chip/Processor to
scamp - Processor 0 (in spin1)
placable - All others Ie where we can place stuff on

In PacmanDatView
system_cores  the cores used for inserted vertices

todo ?
The "monitor" label in the json we pass to the Java