### PR TITLE
Cfg checker

### DIFF
--- a/spinn_machine/spinn_machine.cfg
+++ b/spinn_machine/spinn_machine.cfg
@@ -6,8 +6,6 @@ version = None
 versions = None
 width = None
 height = None
-# Note: if json_path is set all other configs for virtual boards are ignored
-json_path = None
 # Can decrease actual but never increase. Used for testing
 max_sdram_allowed_per_chip = None
 

--- a/spinn_machine/spinn_machine.cfg
+++ b/spinn_machine/spinn_machine.cfg
@@ -45,3 +45,5 @@ spalloc_server = None
 # machine name is typically a URL and then version is required
 machine_name = None
 
+# If using virtual_board both width and height must be set
+virtual_board = False

--- a/spinn_machine/spinn_machine.cfg
+++ b/spinn_machine/spinn_machine.cfg
@@ -42,3 +42,6 @@ max_machine_core = None
 # Urls for servers
 remote_spinnaker_url = None
 spalloc_server = None
+# machine name is typically a URL and then version is required
+machine_name = None
+

--- a/spinn_machine/spinn_machine.cfg
+++ b/spinn_machine/spinn_machine.cfg
@@ -1,4 +1,9 @@
-# Adds or overwrites values in SpiNNUtils/spinn_utilities/spinn_utilities.cfg
+# DO NOT EDIT!
+# The are the default values
+# Edit the cfg in your home directory to change your preferences
+# Add / Edit a cfg in the run directory for script specific changes
+
+# Adds to values in SpiNNUtils/spinn_utilities/spinn_utilities.cfg
 
 [Machine]
 version = None

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -527,3 +527,6 @@ class AbstractVersion(object, metaclass=AbstractBase):
         :rtype: list(int)
         """
         raise NotImplementedError
+
+    def __hash__(self):
+        return self.number

--- a/spinn_machine/version/version_201.py
+++ b/spinn_machine/version/version_201.py
@@ -89,3 +89,6 @@ class Version201(VersionSpin2):
     @overrides(VersionSpin2.fpga_links)
     def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
         return []
+
+    def __eq__(self, other):
+        return isinstance(other, Version201)

--- a/spinn_machine/version/version_248.py
+++ b/spinn_machine/version/version_248.py
@@ -68,3 +68,6 @@ class Version248(VersionSpin2, Version48Chips):
     def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
         # TODO
         return []
+
+    def __eq__(self, other):
+        return isinstance(other, Version248)

--- a/spinn_machine/version/version_3.py
+++ b/spinn_machine/version/version_3.py
@@ -85,3 +85,6 @@ class Version3(VersionSpin1):
     @overrides(VersionSpin1.fpga_links)
     def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
         return []
+
+    def __eq__(self, other):
+        return isinstance(other, Version3)

--- a/spinn_machine/version/version_5.py
+++ b/spinn_machine/version/version_5.py
@@ -82,3 +82,6 @@ class Version5(VersionSpin1, Version48Chips):
                 (7, 5, 0, 2, 12), (7, 5, 1, 2, 11),
                 (7, 6, 0, 2, 10), (7, 6, 1, 2, 9),
                 (7, 7, 0, 2, 8), (7, 7, 1, 2, 7), (7, 7, 2, 2, 6)]
+
+    def __eq__(self, other):
+        return isinstance(other, Version5)

--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -78,6 +78,7 @@ def version_factory() -> AbstractVersion:
             else:
                 raise SpinnMachineException(
                     "cfg width and height do not match other cfg setting.")
+    raise SpinnMachineException("Should not get here")
 
 
 def _get_cfg_version() -> Optional[int]:

--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -15,9 +15,9 @@
 from __future__ import annotations
 import logging
 import sys
-from typing import TYPE_CHECKING
+from typing import Optional,TYPE_CHECKING
 from spinn_utilities.config_holder import (
-    get_config_int_or_none, get_config_str_or_none)
+    get_config_bool, get_config_int_or_none, get_config_str_or_none)
 from spinn_utilities.log import FormatAdapter
 from spinn_machine.exceptions import SpinnMachineException
 from .version_strings import VersionStrings
@@ -35,6 +35,158 @@ SPIN2_48CHIP = 248
 
 
 def version_factory() -> AbstractVersion:
+    """
+    Creates a Machine Version class based on cfg settings.
+
+    :return: A subclass of AbstractVersion
+    :raises SpinnMachineException: If the cfg version is not set correctly
+    """
+    cfg_version = _get_cfg_version()
+    url_version = _get_url_version()
+    size_version = _get_size_version()
+
+    if cfg_version is None:
+        if url_version is None:
+            version: Optional[AbstractVersion] = None
+        else:
+            version = _number_to_version(url_version)
+    else:
+        if url_version is None:
+            version = _number_to_version(cfg_version)
+        else:
+            version_cfg = _number_to_version(cfg_version)
+            version_url = _number_to_version(url_version)
+            if version_cfg == version_url:
+                version = version_cfg
+
+    if size_version is None:
+        if version is None:
+                raise_no_version()
+        else:
+            return version
+    else:
+        if version is None:
+            logger.warning("Please add a version to your cfg file.")
+            return _number_to_version(size_version)
+        else:
+            version_sized = _number_to_version(size_version)
+            if version == version_sized:
+                return version
+            else:
+                raise SpinnMachineException(
+                    "cfg width and height do not match other cfg setting.")
+
+def _get_cfg_version() -> Optional[int]:
+    version = get_config_int_or_none("Machine", "version")
+    versions = get_config_str_or_none("Machine", "versions")
+    if versions is not None:
+        if version is not None:
+            raise SpinnMachineException(
+                f"Both {version=} and {versions=} found in cfg")
+        vs = VersionStrings.from_string(versions)
+        options = vs.options
+        # Use the fact that we run actions against different python versions
+        minor = sys.version_info.minor
+        version = options[minor % len(options)]
+    return version
+
+def _get_url_version() -> Optional[int]:
+    spalloc_server = get_config_str_or_none("Machine", "spalloc_server")
+    remote_spinnaker_url = get_config_str_or_none(
+        "Machine", "remote_spinnaker_url")
+    machine_name = get_config_str_or_none("Machine", "machineName")
+    virtual_board = get_config_bool("Machine", "virtual_board")
+
+    if spalloc_server is not None:
+        if remote_spinnaker_url is not None:
+            raise SpinnMachineException(
+                "Both spalloc_server and remote_spinnaker_url "
+                "specified in cfg")
+        if machine_name is not None:
+            raise SpinnMachineException(
+                "Both spalloc_server and machine_name specified in cfg")
+        if virtual_board:
+            raise SpinnMachineException(
+                "Both spalloc_server and virtual_board specified in cfg")
+        return 5
+
+    if remote_spinnaker_url is not None:
+        if machine_name is not None:
+            raise SpinnMachineException(
+                "Both remote_spinnaker_url and machine_name specified in cfg")
+        if virtual_board:
+            raise SpinnMachineException(
+                "Both remote_spinnaker_url and virtual_board specified in cfg")
+        return 5
+
+    if machine_name is not None:
+        if virtual_board:
+            raise SpinnMachineException(
+                "Both machine_name and virtual_board specified in cfg")
+
+    return None
+
+
+def _get_size_version() -> Optional[int]:
+    height = get_config_int_or_none("Machine", "height")
+    width = get_config_int_or_none("Machine", "width")
+    if height is None:
+        if width is None:
+            return None
+        else:
+            raise SpinnMachineException("cfg has width but not height")
+    else:
+        if width is None:
+            raise SpinnMachineException("cfg has height but not width")
+        else:
+            logger.warning("cfg width and height are deprecated. "
+                           "Please remove then.")
+            if height == width == 2:
+                return 3
+            elif height == width == 1:
+                return 201
+            # if width and height are valid checked later
+            return 5
+
+def _number_to_version(version: int):
+    # Delayed import to avoid circular imports
+    # pylint: disable=import-outside-toplevel
+    from .version_3 import Version3
+    from .version_5 import Version5
+    from .version_201 import Version201
+    from .version_248 import Version248
+
+    if version in [2, 3]:
+        return Version3()
+
+    if version in [4, 5]:
+        return Version5()
+
+    if version == SPIN2_1CHIP:
+        return Version201()
+
+    if version == SPIN2_48CHIP:
+        return Version248()
+
+    raise SpinnMachineException(f"Unexpected cfg [Machine]version {version}")
+
+def raise_no_version():
+    height = get_config_int_or_none("Machine", "height")
+    width = get_config_int_or_none("Machine", "width")
+
+    spalloc_server = get_config_str_or_none("Machine",
+                                            "spalloc_server")
+    remote_spinnaker_url = get_config_str_or_none(
+        "Machine", "remote_spinnaker_url")
+    machine_name = get_config_str_or_none("Machine", "machineName")
+    virtual_board = get_config_bool("Machine", "virtual_board")
+    raise SpinnMachineException(
+        "cfg [Machine]version {version} is None. "
+        f"Other cfg settings are {machine_name=} {spalloc_server=}, "
+        f"{remote_spinnaker_url=} {width=} {height=}")
+
+
+def version_factoryX() -> AbstractVersion:
     """
     Creates a Machine Version class based on cfg settings.
 

--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -78,6 +78,7 @@ def version_factory() -> AbstractVersion:
                 raise SpinnMachineException(
                     "cfg width and height do not match other cfg setting.")
 
+
 def _get_cfg_version() -> Optional[int]:
     version = get_config_int_or_none("Machine", "version")
     versions = get_config_str_or_none("Machine", "versions")

--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 import logging
 import sys
-from typing import Optional,TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 from spinn_utilities.config_holder import (
     get_config_bool, get_config_int_or_none, get_config_str_or_none)
 from spinn_utilities.log import FormatAdapter
@@ -63,7 +63,7 @@ def version_factory() -> AbstractVersion:
 
     if size_version is None:
         if version is None:
-                raise_version_error("No version", None)
+            raise_version_error("No version", None)
         else:
             return version
     else:
@@ -94,6 +94,7 @@ def _get_cfg_version() -> Optional[int]:
         logger.warning(
             "The cfg has no version. This is deprecated! Please add a version")
     return version
+
 
 def _get_url_version() -> Optional[int]:
     spalloc_server = get_config_str_or_none("Machine", "spalloc_server")
@@ -151,6 +152,7 @@ def _get_size_version() -> Optional[int]:
             # if width and height are valid checked later
             return 5
 
+
 def _number_to_version(version: int):
     # Delayed import to avoid circular imports
     # pylint: disable=import-outside-toplevel
@@ -173,6 +175,7 @@ def _number_to_version(version: int):
 
     raise SpinnMachineException(f"Unexpected cfg [Machine]version {version}")
 
+
 def raise_version_error(error: str, version: Optional[int]):
     height = get_config_int_or_none("Machine", "height")
     width = get_config_int_or_none("Machine", "width")
@@ -186,4 +189,4 @@ def raise_version_error(error: str, version: Optional[int]):
     raise SpinnMachineException(
         f"{error} with cfg [Machine] values {version=}, "
         f"{machine_name=}, {spalloc_server=}, {remote_spinnaker_url=}, "
-        f"{width=}, and {height=}")
+        f"{virtual_board=}, {width=}, and {height=}")

--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -45,9 +45,10 @@ def version_factory() -> AbstractVersion:
     url_version = _get_url_version()
     size_version = _get_size_version()
 
+    version: Optional[AbstractVersion] = None
     if cfg_version is None:
         if url_version is None:
-            version: Optional[AbstractVersion] = None
+            version = None
         else:
             version = _number_to_version(url_version)
     else:
@@ -178,6 +179,14 @@ def _number_to_version(version: int):
 
 
 def raise_version_error(error: str, version: Optional[int]):
+    """
+    Collects main cfg values and raises an exception
+
+    :param str error: message for the exception
+    :param version: version claimed
+    :type version: int or None
+    :raises SpinnMachineException: Always!
+    """
     height = get_config_int_or_none("Machine", "height")
     width = get_config_int_or_none("Machine", "width")
 

--- a/unittests/test_version_factory.py
+++ b/unittests/test_version_factory.py
@@ -63,12 +63,6 @@ class TestVersionFactory(unittest.TestCase):
     def test_bad_spalloc_and_name(self):
         set_config("Machine", "spalloc_server", "Somewhere")
         set_config("Machine", "machine_name", "Somewhere")
-        #with self.assertRaises(SpinnMachineException):
-        version_factory()
-
-    def test_bad_spalloc_and_name(self):
-        set_config("Machine", "spalloc_server", "Somewhere")
-        set_config("Machine", "machine_name", "Somewhere")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 

--- a/unittests/test_version_factory.py
+++ b/unittests/test_version_factory.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2014 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from spinn_utilities.config_holder import set_config
+from spinn_machine.config_setup import unittest_setup
+from spinn_machine.exceptions import (
+    SpinnMachineException)
+from spinn_machine.version.version_5 import Version5
+from spinn_machine.version.version_factory import version_factory
+
+
+class TestVersionFactory(unittest.TestCase):
+
+    def setUp(self):
+        unittest_setup()
+
+    def test_no_info(self):
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_bad_spalloc_3(self):
+        set_config("Machine", "version", 3)
+        set_config("Machine", "spalloc_server", "Somewhere")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_ok_spalloc_4(self):
+        set_config("Machine", "version", 4)
+        set_config("Machine", "spalloc_server", "Somewhere")
+        version = version_factory()
+        self.assertEqual(Version5(), version)
+
+    def test_ok_spalloc(self):
+        # warning this behaviour may break if spalloc ever support spin2
+        set_config("Machine", "spalloc_server", "Somewhere")
+        version = version_factory()
+        self.assertEqual(Version5(), version)
+
+    def test_ok_remote_5(self):
+        set_config("Machine", "version", 4)
+        set_config("Machine", "remote_spinnaker_url", "Somewhere")
+        version = version_factory()
+        self.assertEqual(Version5(), version)
+
+    def test_bad_spalloc_and_remote(self):
+        set_config("Machine", "spalloc_server", "Somewhere")
+        set_config("Machine", "remote_spinnaker_url", "Somewhere")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_bad_spalloc_and_name(self):
+        set_config("Machine", "spalloc_server", "Somewhere")
+        set_config("Machine", "machine_name", "Somewhere")
+        #with self.assertRaises(SpinnMachineException):
+        version_factory()
+
+    def test_bad_spalloc_and_name(self):
+        set_config("Machine", "spalloc_server", "Somewhere")
+        set_config("Machine", "machine_name", "Somewhere")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_bad_spalloc_and_virtual(self):
+        set_config("Machine", "spalloc_server", "Somewhere")
+        set_config("Machine", "virtual_board", "True")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_bad_remote_and_name(self):
+        set_config("Machine", "remote_spinnaker_url", "Somewhere")
+        set_config("Machine", "machine_name", "Somewhere")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_bad_remote_and_virtual(self):
+        set_config("Machine", "remote_spinnaker_url", "Somewhere")
+        set_config("Machine", "virtual_board", "True")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+    def test_bad_name_and_virtual(self):
+        set_config("Machine", "machine_name", "Somewhere")
+        set_config("Machine", "virtual_board", "True")
+        with self.assertRaises(SpinnMachineException):
+            version_factory()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
part of https://github.com/SpiNNakerManchester/SpiNNUtils/pull/274

Version Factory will now raise a better error if there is conflicting info is found in the cfg.

To check if the info is conflicting Versions now have an eg and so hash function.