### PR TITLE
T machine

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -26,6 +26,5 @@ jobs:
       coverage-package: spinn_machine
       flake8-packages: spinn_machine unittests
       pylint-packages: spinn_machine
-      mypy-packages: unittests
-      mypy-full_packages: spinn_machine
+      mypy-full_packages: spinn_machine unittests
     secrets: inherit

--- a/mypyd.bash
+++ b/mypyd.bash
@@ -21,4 +21,4 @@
 
 utils="../SpiNNUtils/spinn_utilities"
 
-mypy --python-version 3.8 --disallow-untyped-defs $utils spinn_machine
+mypy --python-version 3.8 --disallow-untyped-defs $utils spinn_machine unittests

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -26,10 +26,10 @@ from spinn_machine.version.version_strings import VersionStrings
 
 class TestSimulatorData(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_setup(self):
+    def test_setup(self) -> None:
         # What happens before setup depends on the previous test
         # Use manual_check to verify this without dependency
         MachineDataWriter.setup()
@@ -38,13 +38,13 @@ class TestSimulatorData(unittest.TestCase):
         with self.assertRaises(DataNotYetAvialable):
             MachineDataView.get_chip_at(1, 1)
 
-    def test_mock(self):
-        set_config("Machine", "version", FIVE)
+    def test_mock(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         self.assertEqual(3, MachineDataView.get_chip_at(3, 5).x)
         self.assertEqual(48, MachineDataView.get_machine().n_chips)
 
-    def test_machine(self):
-        set_config("Machine", "version", THREE)
+    def test_machine(self) -> None:
+        set_config("Machine", "version", str(THREE))
         writer = MachineDataWriter.setup()
 
         with self.assertRaises(DataNotYetAvialable):
@@ -56,10 +56,10 @@ class TestSimulatorData(unittest.TestCase):
         with self.assertRaises(KeyError):
             MachineDataView.get_chip_at(4, 4)
         with self.assertRaises(TypeError):
-            writer.set_machine("bacon")
+            writer.set_machine("bacon")  # type: ignore[arg-type]
         self.assertTrue(MachineDataView.has_machine())
 
-    def test_where_is_mocked(self):
+    def test_where_is_mocked(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         writer = MachineDataWriter.mock()
         self.assertEqual(
@@ -75,9 +75,9 @@ class TestSimulatorData(unittest.TestCase):
             MachineDataView.where_is_xy(11, 11))
         self.assertEqual(
             "global chip 2, 8 on 127.0.0.0 is chip 6, 4 on 127.0.8.4",
-            MachineDataView.where_is_chip(machine.get_chip_at(2, 8)))
+            MachineDataView.where_is_chip(machine[2, 8]))
 
-    def test_where_is_setup(self):
+    def test_where_is_setup(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         writer = MachineDataWriter.setup()
         self.assertEqual(
@@ -93,15 +93,15 @@ class TestSimulatorData(unittest.TestCase):
             MachineDataView.where_is_xy(-1, 11))
         self.assertEqual(
             "global chip 2, 8 on 127.0.0.0 is chip 6, 4 on 127.0.8.4",
-            MachineDataView.where_is_chip(machine.get_chip_at(2, 8)))
+            MachineDataView.where_is_chip(machine[2, 8]))
         self.assertEqual(
             "None",
-            MachineDataView.where_is_chip(None)
+            MachineDataView.where_is_chip(None)  # type: ignore[arg-type]
         )
 
-    def test_v_to_p_spin1(self):
+    def test_v_to_p_spin1(self) -> None:
         writer = MachineDataWriter.setup()
-        set_config("Machine", "version", FIVE)
+        set_config("Machine", "version", str(FIVE))
         # Before setting
         with self.assertRaises(DataNotYetAvialable):
             writer.get_physical_core_id((1, 2), 3)
@@ -125,9 +125,9 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual("",
                          writer.get_physical_string((1, 2), 19))
 
-    def test_v_to_p_spin2(self):
+    def test_v_to_p_spin2(self) -> None:
         writer = MachineDataWriter.setup()
-        set_config("Machine", "version", SPIN2_48CHIP)
+        set_config("Machine", "version", str(SPIN2_48CHIP))
 
         # exists
         self.assertEqual((7, 6, 2), writer.get_physical_quad(3))
@@ -138,44 +138,44 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual("",
                          writer.get_physical_string((1, 2), 234))
 
-    def test_mock_any(self):
+    def test_mock_any(self) -> None:
         # Should work with any version
         set_config("Machine", "versions", VersionStrings.ANY.text)
         # check there is a value not what it is
         machine = MachineDataView.get_machine()
         self.assertGreaterEqual(machine.n_chips, 1)
 
-    def test_mock_4_or_more(self):
+    def test_mock_4_or_more(self) -> None:
         # Should work with any version that has 4 plus Chips
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         # check there is a value not what it is
         machine = MachineDataView.get_machine()
         self.assertGreaterEqual(machine.n_chips, 4)
 
-    def test_mock_big(self):
+    def test_mock_big(self) -> None:
         # Should work with any version
         set_config("Machine", "versions", VersionStrings.BIG.text)
         # check there is a value not what it is
         machine = MachineDataView.get_machine()
         self.assertGreaterEqual(machine.n_chips, 48)
 
-    def test_mock3(self):
+    def test_mock3(self) -> None:
         # Should work with any version
-        set_config("Machine", "version", 3)
+        set_config("Machine", "version", "3")
         # check there is a value not what it is
         MachineDataView.get_machine()
 
-    def test_mock5(self):
-        set_config("Machine", "version", 5)
+    def test_mock5(self) -> None:
+        set_config("Machine", "version", "5")
         # check there is a value not what it is
         MachineDataView.get_machine()
 
-    def test_mock201(self):
-        set_config("Machine", "version", 201)
+    def test_mock201(self) -> None:
+        set_config("Machine", "version", "201")
         # check there is a value not what it is
         MachineDataView.get_machine()
 
-    def test_get_monitors(self):
+    def test_get_monitors(self) -> None:
         writer = MachineDataWriter.setup()
         self.assertEqual(0, MachineDataView.get_all_monitor_cores())
         self.assertEqual(0, MachineDataView.get_ethernet_monitor_cores())
@@ -187,7 +187,7 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(2, MachineDataView.get_all_monitor_cores())
         self.assertEqual(3, MachineDataView.get_ethernet_monitor_cores())
 
-    def test_no_version(self):
+    def test_no_version(self) -> None:
         set_config("Machine", "machineName", "SpiNNaker1M")
         try:
             MachineDataView.get_machine_version()

--- a/unittests/tag_tests/test_iptag.py
+++ b/unittests/tag_tests/test_iptag.py
@@ -23,10 +23,10 @@ from spinn_machine.config_setup import unittest_setup
 class TestingIptag(unittest.TestCase):
     """ Tests of IPTag
     """
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_valid_iptag(self):
+    def test_create_valid_iptag(self) -> None:
         """ test if an IP tag with valid inputs works
 
         :rtype: None
@@ -34,7 +34,7 @@ class TestingIptag(unittest.TestCase):
         iptag = IPTag("", 0, 0, 0, "", 1)
         self.assertIsNotNone(iptag)
 
-    def test_retrival_of_board_address(self):
+    def test_retrival_of_board_address(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -44,7 +44,7 @@ class TestingIptag(unittest.TestCase):
         board_address = iptag.board_address
         self.assertEqual("", board_address)
 
-    def test_retrival_of_ip_address(self):
+    def test_retrival_of_ip_address(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -54,7 +54,7 @@ class TestingIptag(unittest.TestCase):
         ip_address = iptag.ip_address
         self.assertEqual("", ip_address)
 
-    def test_retrival_of_tag(self):
+    def test_retrival_of_tag(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -64,7 +64,7 @@ class TestingIptag(unittest.TestCase):
         tag = iptag.tag
         self.assertEqual(tag, 0)
 
-    def test_retrival_of_port(self):
+    def test_retrival_of_port(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -74,7 +74,7 @@ class TestingIptag(unittest.TestCase):
         port = iptag.port
         self.assertEqual(port, 1)
 
-    def test_retrival_of_strip_sdp(self):
+    def test_retrival_of_strip_sdp(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -84,14 +84,14 @@ class TestingIptag(unittest.TestCase):
         strip_sdp = iptag.strip_sdp
         self.assertEqual(strip_sdp, False)
 
-    def test_tag_rendering(self):
+    def test_tag_rendering(self) -> None:
         iptag = IPTag("localhost", 1, 2, 3, "abc", 4, True)
         assert iptag.__repr__() == (
             "IPTag(board_address=localhost, destination_x=1, destination_y=2, "
             "tag=3, port=4, ip_address=abc, strip_sdp=True, "
             "traffic_identifier=DEFAULT)")
 
-    def test_in_dict(self):
+    def test_in_dict(self) -> None:
         d = dict()
         iptag_1 = IPTag("", 0, 0, 0, "", 1)
         d[iptag_1] = 1
@@ -102,7 +102,7 @@ class TestingIptag(unittest.TestCase):
         assert d[iptag_2] == 10
         assert len(d) == 2
 
-    def test_no_equals(self):
+    def test_no_equals(self) -> None:
         iptag = IPTag("", 0, 0, 0, "", 1)
         self.assertNotEqual(iptag, "foo")
 

--- a/unittests/tag_tests/test_reverse_iptag.py
+++ b/unittests/tag_tests/test_reverse_iptag.py
@@ -24,10 +24,10 @@ class TestingReverseIptag(unittest.TestCase):
     """ Tests of ReverseIPTag
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_valid_reverse_iptag(self):
+    def test_create_valid_reverse_iptag(self) -> None:
         """ test if a reverse IP tag with valid inputs works
 
         :rtype: None
@@ -35,7 +35,7 @@ class TestingReverseIptag(unittest.TestCase):
         reverse_ip_tag = ReverseIPTag("", 0, 1, 0, 0, 1)
         self.assertIsNotNone(reverse_ip_tag)
 
-    def test_retrival_of_board_address(self):
+    def test_retrival_of_board_address(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -45,7 +45,7 @@ class TestingReverseIptag(unittest.TestCase):
         board_address = reverse_ip_tag.board_address
         self.assertEqual("", board_address)
 
-    def test_retrival_of_tag(self):
+    def test_retrival_of_tag(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -55,7 +55,7 @@ class TestingReverseIptag(unittest.TestCase):
         tag = reverse_ip_tag.tag
         self.assertEqual(0, tag)
 
-    def test_retrival_of_port(self):
+    def test_retrival_of_port(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -65,7 +65,7 @@ class TestingReverseIptag(unittest.TestCase):
         port = reverse_ip_tag.port
         self.assertEqual(port, 1)
 
-    def test_retrival_of_dest_x(self):
+    def test_retrival_of_dest_x(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -75,7 +75,7 @@ class TestingReverseIptag(unittest.TestCase):
         destination_x = reverse_ip_tag.destination_x
         self.assertEqual(destination_x, 0)
 
-    def test_retrival_of_dest_y(self):
+    def test_retrival_of_dest_y(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -85,7 +85,7 @@ class TestingReverseIptag(unittest.TestCase):
         destination_y = reverse_ip_tag.destination_y
         self.assertEqual(destination_y, 0)
 
-    def test_retrival_of_dest_p(self):
+    def test_retrival_of_dest_p(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -95,7 +95,7 @@ class TestingReverseIptag(unittest.TestCase):
         destination_p = reverse_ip_tag.destination_p
         self.assertEqual(destination_p, 1)
 
-    def test_retrival_of_sdp_port(self):
+    def test_retrival_of_sdp_port(self) -> None:
         """ test if the board address retrieval works
 
         :rtype: None
@@ -105,7 +105,7 @@ class TestingReverseIptag(unittest.TestCase):
         sdp_port = reverse_ip_tag.sdp_port
         self.assertEqual(sdp_port, 1)
 
-    def test_tag_rendering(self):
+    def test_tag_rendering(self) -> None:
         riptag = ReverseIPTag("somewhere.local", 2, 3, 4, 5, 6)
         assert riptag.__repr__() == (
             "ReverseIPTag(board_address=somewhere.local, tag=2, port=3, "

--- a/unittests/test_cfg_checker.py
+++ b/unittests/test_cfg_checker.py
@@ -21,10 +21,10 @@ from spinn_machine.config_setup import unittest_setup
 
 class TestCfgChecker(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_cfg_checker(self):
+    def test_cfg_checker(self) -> None:
         unittests_dir = os.path.dirname(__file__)
         spinn_machine_dir = spinn_machine.__path__[0]
         run_config_checks(directories=[spinn_machine_dir, unittests_dir])

--- a/unittests/test_chip.py
+++ b/unittests/test_chip.py
@@ -22,7 +22,7 @@ from spinn_machine.version.version_strings import VersionStrings
 
 class TestingChip(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
         set_config("Machine", "versions", VersionStrings.ANY.text)
         self._x = 0
@@ -45,7 +45,7 @@ class TestingChip(unittest.TestCase):
     def _create_chip(self, x, y, processors, r, sdram, ip):
         return Chip(x, y, [0], range(1, processors), r, sdram, 0, 0, ip)
 
-    def test_create_chip(self):
+    def test_create_chip(self) -> None:
         new_chip = self._create_chip(self._x, self._y, self.n_processors,
                                      self._router, self._sdram, self._ip)
 
@@ -64,18 +64,17 @@ class TestingChip(unittest.TestCase):
         self.assertEqual(new_chip.tag_ids, OrderedSet([1, 2, 3, 4, 5, 6, 7]))
         self.assertTrue(new_chip.is_processor_with_id(3))
 
-    def test_0_down(self):
+    def test_0_down(self) -> None:
         Chip(1, 1, [1], range(3, self.n_processors), self._router,
              self._sdram, 0, 0, self._ip)
 
-    def test_1_chip(self):
+    def test_1_chip(self) -> None:
         # Chip with just 1 processor
         new_chip = Chip(1, 1, [0], [], self._router, self._sdram, 0, 0,
                         self._ip)
-        with self.assertRaises(Exception):
-            new_chip.get_first_none_monitor_processor()
+        self.assertEqual((), new_chip.placable_processors_ids)
 
-    def test_processors(self):
+    def test_processors(self) -> None:
         new_chip = self._create_chip(self._x, self._y, self.n_processors,
                                      self._router, self._sdram, self._ip)
         all_p = set(new_chip.all_processor_ids)
@@ -85,7 +84,7 @@ class TestingChip(unittest.TestCase):
         monitors = set(new_chip.scamp_processors_ids)
         self.assertEqual(users.union(monitors), all_p)
 
-    def test_is_xy(self):
+    def test_is_xy(self) -> None:
         chip24 = self._create_chip(
             2, 4, self.n_processors, self._router, self._sdram, None)
         chip36 = self._create_chip(

--- a/unittests/test_frozencoresubsets.py
+++ b/unittests/test_frozencoresubsets.py
@@ -19,7 +19,7 @@ from spinn_machine.config_setup import unittest_setup
 
 class TestFrozenCoreSubsets(unittest.TestCase):
 
-    def test_multiple(self):
+    def test_multiple(self) -> None:
         unittest_setup()
         cs1 = CoreSubset(0, 0, [1, 2, 3])
         cs2 = CoreSubset(0, 0, [4, 5, 6])

--- a/unittests/test_ignore_cores.py
+++ b/unittests/test_ignore_cores.py
@@ -26,10 +26,10 @@ from spinn_machine.version.version_strings import VersionStrings
 
 class TestDownCores(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_bad_ignores(self):
+    def test_bad_ignores(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
 
         try:
@@ -50,25 +50,25 @@ class TestDownCores(unittest.TestCase):
         except Exception as ex:
             self.assertTrue("downed_link" in str(ex))
 
-    def test_down_cores_bad_string(self):
+    def test_down_cores_bad_string(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         with self.assertRaises(ConfigException):
             IgnoreCore.parse_string("4,4,bacon")
 
-    def test_qx_qy_qp_to_id_spin2(self):
+    def test_qx_qy_qp_to_id_spin2(self) -> None:
         version = Version201()
         self.assertEqual(75, version.qx_qy_qp_to_id(3, 4, 2))
         self.assertEqual((3, 4, 2), version.id_to_qx_qy_qp(75))
 
-    def test_qx_qy_qp_to_spin1(self):
+    def test_qx_qy_qp_to_spin1(self) -> None:
         version = Version5()
         with self.assertRaises(SpinnMachineException):
             self.assertEqual(75, version.qx_qy_qp_to_id(3, 4, 2))
         with self.assertRaises(SpinnMachineException):
             self.assertEqual((3, 4, 2), version.id_to_qx_qy_qp(75))
 
-    def test_version_401(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_version_401(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         ignores = IgnoreCore.parse_string("0,0,3.4.2")
         self.assertEqual(1, len(ignores))
         for ignore in ignores:

--- a/unittests/test_import_all_test.py
+++ b/unittests/test_import_all_test.py
@@ -20,5 +20,5 @@ class ImportAllModule(unittest.TestCase):
 
     # no unittest_setup to check all imports work without it
 
-    def test_import_all(self):
+    def test_import_all(self) -> None:
         package_loader.load_module("spinn_machine")

--- a/unittests/test_json_machine.py
+++ b/unittests/test_json_machine.py
@@ -22,15 +22,16 @@ from spinn_machine.config_setup import unittest_setup
 from spinn_machine.json_machine import (machine_from_json, to_json_path)
 from spinn_machine.version import (FIVE, SPIN2_1CHIP, THREE)
 from spinn_machine.version.version_strings import VersionStrings
+from spinn_utilities.ordered_set import OrderedSet
 
 
 class TestJsonMachine(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_json_version_3(self):
-        set_config("Machine", "version", THREE)
+    def test_json_version_3(self) -> None:
+        set_config("Machine", "version", str(THREE))
         vm = virtual_machine(width=2, height=2)
         MachineDataWriter.mock().set_machine(vm)
         jpath = mktemp("json")
@@ -42,8 +43,8 @@ class TestJsonMachine(unittest.TestCase):
         for vchip, jchip in zip(vm, jm):
             self.assertEqual(str(vchip), str(jchip))
 
-    def test_json_version_5(self):
-        set_config("Machine", "version", FIVE)
+    def test_json_version_5(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(width=8, height=8)
         MachineDataWriter.mock().set_machine(vm)
         jpath = mktemp("json")
@@ -55,8 +56,8 @@ class TestJsonMachine(unittest.TestCase):
         for vchip, jchip in zip(vm, jm):
             self.assertEqual(str(vchip), str(jchip))
 
-    def test_json_version_201(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_json_version_201(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(width=1, height=1)
         MachineDataWriter.mock().set_machine(vm)
         jpath = mktemp("json")
@@ -68,7 +69,7 @@ class TestJsonMachine(unittest.TestCase):
         for vchip, jchip in zip(vm, jm):
             self.assertEqual(str(vchip), str(jchip))
 
-    def test_json_hole(self):
+    def test_json_hole(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         set_config("Machine", "down_chips", "3,3")
         writer = MachineDataWriter.mock()
@@ -83,7 +84,7 @@ class TestJsonMachine(unittest.TestCase):
         for vchip, jchip in zip(vm, jm):
             self.assertEqual(str(vchip), str(jchip))
 
-    def test_exceptions(self):
+    def test_exceptions(self) -> None:
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         writer = MachineDataWriter.mock()
         vm = virtual_machine_by_boards(1)
@@ -94,7 +95,7 @@ class TestJsonMachine(unittest.TestCase):
             router01._n_available_multicast_entries - 20
         chip10 = vm[1, 0]
         chip10._sdram = 50000000
-        chip10._tag_ids = [2, 3]
+        chip10._tag_ids = OrderedSet([2, 3])
         jpath = mktemp("json")
         to_json_path(jpath)
         jm = machine_from_json(jpath)
@@ -103,7 +104,7 @@ class TestJsonMachine(unittest.TestCase):
         vchip10 = jm[1, 0]
         self.assertEqual(vchip10.tag_ids, chip10.tag_ids)
 
-    def test_monitor_exceptions(self):
+    def test_monitor_exceptions(self) -> None:
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         vm = virtual_machine_by_boards(1)
         MachineDataWriter.mock().set_machine(vm)
@@ -120,7 +121,7 @@ class TestJsonMachine(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             machine_from_json(jpath)
 
-    def test_ethernet_exceptions(self):
+    def test_ethernet_exceptions(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         vm = virtual_machine_by_boards(2)
         MachineDataWriter.mock().set_machine(vm)
@@ -129,7 +130,7 @@ class TestJsonMachine(unittest.TestCase):
         router2._n_available_multicast_entries = \
             router2._n_available_multicast_entries - 20
         eth2._sdram = 50000000
-        eth2._tag_ids = [2, 3]
+        eth2._tag_ids = OrderedSet([2, 3])
         jpath = mktemp("json")
         to_json_path(jpath)
         jm = machine_from_json(jpath)

--- a/unittests/test_link.py
+++ b/unittests/test_link.py
@@ -19,10 +19,10 @@ from spinn_machine.config_setup import unittest_setup
 
 class TestingLinks(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_create_new_link(self):
+    def test_create_new_link(self) -> None:
         links = list()
         links.append(Link(0, 0, 0, 0, 1))
         self.assertEqual(links[0].source_x, 0)

--- a/unittests/test_link_data.py
+++ b/unittests/test_link_data.py
@@ -19,10 +19,10 @@ from spinn_machine.link_data_objects import FPGALinkData, SpinnakerLinkData
 
 class TestingLinks(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_fpga_link_data(self):
+    def test_fpga_link_data(self) -> None:
         ld = FPGALinkData(1, 2, 3, 4, 5, "somehost")
         ld2 = FPGALinkData(1, 2, 3, 4, 5, "somehost")
         ld3 = FPGALinkData(1, 2, 3, 4, 6, "somehost")
@@ -42,7 +42,7 @@ class TestingLinks(unittest.TestCase):
         d[ld3] = 3
         self.assertEqual(len(d), 2)
 
-    def test_spinnaker_link_data(self):
+    def test_spinnaker_link_data(self) -> None:
         ld = SpinnakerLinkData(2, 3, 4, 5, "somehost")
         ld2 = SpinnakerLinkData(2, 3, 4, 5, "somehost")
         ld3 = SpinnakerLinkData(2, 3, 4, 6, "somehost")

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -35,7 +35,7 @@ class SpinnMachineTestCase(unittest.TestCase):
     test for testing the python representation of a spinnaker machine
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
         self._sdram = 123469792
@@ -61,12 +61,12 @@ class SpinnMachineTestCase(unittest.TestCase):
                     self._nearest_ethernet_chip[0],
                     self._nearest_ethernet_chip[1], None)
 
-    def test_create_new_machine_version5(self):
+    def test_create_new_machine_version5(self) -> None:
         """
         test creating a new machine
         """
         # Tests the version 5 values specifically
-        set_config("Machine", "version", FIVE)
+        set_config("Machine", "version", str(FIVE))
         new_machine = virtual_machine_by_boards(1)
 
         self.assertEqual(new_machine.width, 8)
@@ -94,9 +94,9 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertEqual(2, len(list(new_machine.spinnaker_links)))
         self.assertEqual(1023, new_machine.min_n_router_enteries)
 
-    def test_summary(self):
+    def test_summary(self) -> None:
         # Strings hard coded to version 5
-        set_config("Machine", "version", FIVE)
+        set_config("Machine", "version", str(FIVE))
         machine = virtual_machine_by_boards(1)
         self.assertEqual(
             "Machine on 127.0.0.0 with 48 Chips, 856 cores and 120.0 links. "
@@ -144,7 +144,7 @@ class SpinnMachineTestCase(unittest.TestCase):
                 "Not all Chips had the same n_router_tables. "
                 "The counts where Counter({456: 1, 321: 1}).")
 
-    def test_chip_already_exists(self):
+    def test_chip_already_exists(self) -> None:
         """
         check that adding a chip that already exists causes an error
 
@@ -158,7 +158,7 @@ class SpinnMachineTestCase(unittest.TestCase):
                 self._nearest_ethernet_chip[0],
                 self._nearest_ethernet_chip[1], self._ip))
 
-    def test_machine_get_chip_at(self):
+    def test_machine_get_chip_at(self) -> None:
         """
         test the get_chip_at function from the machine with a valid request
 
@@ -166,12 +166,12 @@ class SpinnMachineTestCase(unittest.TestCase):
         """
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         new_machine = virtual_machine_by_min_size(2, 2)
-        self.assertEqual(1, new_machine.get_chip_at(1, 0).x)
-        self.assertEqual(0, new_machine.get_chip_at(1, 0).y)
-        self.assertEqual(0, new_machine.get_chip_at(0, 1).x)
-        self.assertEqual(1, new_machine.get_chip_at(0, 1).y)
+        self.assertEqual(1, new_machine[1, 0].x)
+        self.assertEqual(0, new_machine[1, 0].y)
+        self.assertEqual(0, new_machine[0, 1].x)
+        self.assertEqual(1, new_machine[0, 1].y)
 
-    def test_machine_big_x(self):
+    def test_machine_big_x(self) -> None:
         """
         test the add_chips method of the machine chips outside size
         should produce an error
@@ -192,7 +192,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         except SpinnMachineException as ex:
             self.assertIn(f"has an x larger than width {width}", str(ex))
 
-    def test_machine_big_y(self):
+    def test_machine_big_y(self) -> None:
         """
         test the add_chips method of the machine chips outside size
         should produce an error
@@ -213,7 +213,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         except SpinnMachineException as ex:
             self.assertIn(f"has a y larger than height {height}", str(ex))
 
-    def test_machine_get_chip_at_invalid_location(self):
+    def test_machine_get_chip_at_invalid_location(self) -> None:
         """
         test the machines get_chip_at function with a location thats invalid,
         should return None and not produce an error
@@ -226,7 +226,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         width, height = version.board_shape
         self.assertEqual(None, new_machine.get_chip_at(width + 2, height // 2))
 
-    def test_machine_is_chip_at_true(self):
+    def test_machine_is_chip_at_true(self) -> None:
         """
         test the is_chip_at function of the machine with a position to
         request which does indeed contain a chip
@@ -239,7 +239,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         width, height = version.board_shape
         self.assertTrue(new_machine.is_chip_at(width // 2, height // 2))
 
-    def test_machine_is_chip_at_false(self):
+    def test_machine_is_chip_at_false(self) -> None:
         """
         test the is_chip_at function of the machine with a position to
         request which does not contain a chip
@@ -252,7 +252,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         width, height = version.board_shape
         self.assertFalse(new_machine.is_chip_at(width + 2, height // 2))
 
-    def test_machine_get_chips_on_board(self):
+    def test_machine_get_chips_on_board(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         new_machine = virtual_machine_by_boards(3)
         version = MachineDataView.get_machine_version()
@@ -266,7 +266,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         with self.assertRaises(KeyError):
             new_machine.get_fpga_link_with_id(3, 3)
 
-    def test_x_y_over_link(self):
+    def test_x_y_over_link(self) -> None:
         """
         Test the x_y with each wrap around.
 
@@ -295,7 +295,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertEqual(machine.xy_over_link(15, 23, 1), (16, 0))
         self.assertEqual(machine.wrap, "VerWrap")
 
-    def test_get_global_xy(self):
+    def test_get_global_xy(self) -> None:
         """
         Test get_global_xy with each wrap around.
 
@@ -320,7 +320,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertEqual(machine.get_global_xy(1, 4, 4, 20), (5, 0))
         self.assertEqual(machine.get_global_xy(5, 0, 20, 4), (25, 4))
 
-    def test_no_boot(self):
+    def test_no_boot(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         version = MachineDataView.get_machine_version()
         width, height = version.board_shape
@@ -329,7 +329,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             machine.validate()
 
-    def test_negative_x(self):
+    def test_negative_x(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         version = MachineDataView.get_machine_version()
         width, height = version.board_shape
@@ -340,7 +340,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             machine.validate()
 
-    def test_negative_y(self):
+    def test_negative_y(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         version = MachineDataView.get_machine_version()
         width, height = version.board_shape
@@ -357,14 +357,14 @@ class SpinnMachineTestCase(unittest.TestCase):
                 return chip
         raise SpinnMachineException("No none Ethernet Chip")
 
-    def test_weird_ethernet1(self):
+    def test_weird_ethernet1(self) -> None:
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         machine = virtual_machine_by_boards(1)
         self._non_ethernet_chip(machine)._ip_address = "1.2.3.4"
         with self.assertRaises(SpinnMachineException):
             machine.validate()
 
-    def test_bad_ethernet_chip_x(self):
+    def test_bad_ethernet_chip_x(self) -> None:
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         machine = virtual_machine_by_boards(1)
         width, _ = MachineDataView.get_machine_version().board_shape
@@ -372,7 +372,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             machine.validate()
 
-    def test_bad_ethernet_chip_no_chip(self):
+    def test_bad_ethernet_chip_no_chip(self) -> None:
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         machine = virtual_machine_by_boards(1)
         _, height = MachineDataView.get_machine_version().board_shape
@@ -380,7 +380,7 @@ class SpinnMachineTestCase(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             machine.validate()
 
-    def test_concentric_xys(self):
+    def test_concentric_xys(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine_by_min_size(5, 5)
         found = list(machine.concentric_xys(2, (2, 2)))
@@ -391,7 +391,7 @@ class SpinnMachineTestCase(unittest.TestCase):
             (2, 4), (1, 3), (0, 2), (0, 1), (0, 0), (1, 0)]
         self.assertListEqual(expected, found)
 
-    def test_too_few_cores(self):
+    def test_too_few_cores(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         machine = virtual_machine_by_boards(1)
         # Hack to get n_processors return a low number

--- a/unittests/test_multicast_routing_entry.py
+++ b/unittests/test_multicast_routing_entry.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pickle
+from typing import List
 import unittest
 from spinn_machine import MulticastRoutingEntry, RoutingEntry
 from spinn_machine.config_setup import unittest_setup
@@ -21,10 +22,10 @@ from spinn_machine.exceptions import SpinnMachineInvalidParameterException
 
 class TestMulticastRoutingEntry(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_creating_new_multicast_routing_entry(self):
+    def test_creating_new_multicast_routing_entry(self) -> None:
         link_ids = list()
         proc_ids = list()
         for i in range(6):
@@ -51,9 +52,9 @@ class TestMulticastRoutingEntry(unittest.TestCase):
             pickle.loads(pickle.dumps(a_multicast, pickle.HIGHEST_PROTOCOL)))
         hash(a_multicast)
 
-    def test_creating_defaulatble_multicast_routing_entry(self):
+    def test_creating_defaulatble_multicast_routing_entry(self) -> None:
         link_ids = list()
-        proc_ids = list()
+        proc_ids: List[int] = list()
         link_ids.append(2)
         key = 1
         mask = 1
@@ -74,11 +75,11 @@ class TestMulticastRoutingEntry(unittest.TestCase):
             pickle.loads(pickle.dumps(a_multicast, pickle.HIGHEST_PROTOCOL)))
         hash(a_multicast)
 
-    def test_bad_key_mask(self):
+    def test_bad_key_mask(self) -> None:
         with self.assertRaises(SpinnMachineInvalidParameterException):
-            MulticastRoutingEntry(1, 2, None)
+            MulticastRoutingEntry(1, 2, None)  # type: ignore[arg-type]
 
-    def test_spinnaker_route(self):
+    def test_spinnaker_route(self) -> None:
         multicast1 = MulticastRoutingEntry(1, 1, RoutingEntry(
             processor_ids=[1, 3, 4, 16], link_ids=[2, 3, 5]))
         self.assertEqual(4196012, multicast1.spinnaker_route)
@@ -91,7 +92,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(multicast3.link_ids, {2, 3, 5})
         self.assertEqual(multicast3.processor_ids, {1, 3, 4, 16})
 
-    def test_merger(self):
+    def test_merger(self) -> None:
         link_ids = list()
         link_ids2 = list()
         proc_ids = list()
@@ -129,7 +130,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(result_multicast.processor_ids,
                          set(comparison_proc_ids))
 
-    def test_merger_with_different_defaultable(self):
+    def test_merger_with_different_defaultable(self) -> None:
         key = 1
         mask = 1
         a_multicast = MulticastRoutingEntry(key, mask, RoutingEntry(
@@ -147,7 +148,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(result_multicast.processor_ids, set())
         assert not result_multicast.defaultable
 
-    def test_merger_with_invalid_parameter_key(self):
+    def test_merger_with_invalid_parameter_key(self) -> None:
         link_ids = list()
         link_ids2 = list()
         proc_ids = list()
@@ -172,7 +173,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(e.exception.value, "0x2")
         self.assertEqual(e.exception.problem, "The key does not match 0x1")
 
-    def test_merger_with_invalid_parameter_mask(self):
+    def test_merger_with_invalid_parameter_mask(self) -> None:
         link_ids = list()
         link_ids2 = list()
         proc_ids = list()

--- a/unittests/test_router.py
+++ b/unittests/test_router.py
@@ -20,10 +20,10 @@ from spinn_machine.exceptions import SpinnMachineAlreadyExistsException
 
 class TestingRouter(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_creating_new_router(self):
+    def test_creating_new_router(self) -> None:
         links = list()
         links.append(Link(0, 0, 0, 1, 1))
         links.append(Link(0, 1, 1, 1, 0))
@@ -63,7 +63,7 @@ class TestingRouter(unittest.TestCase):
             "[Link: source_x=1, source_y=0, source_link_id=3, "
             "destination_x=0, destination_y=1]]]")
 
-    def test_creating_new_router_with_duplicate_links(self):
+    def test_creating_new_router_with_duplicate_links(self) -> None:
         links = list()
         (e, ne, n, w, sw, s) = range(6)
         links.append(Link(0, 0, 0, 0, 1))

--- a/unittests/test_routing_entry.py
+++ b/unittests/test_routing_entry.py
@@ -20,10 +20,10 @@ from spinn_machine.config_setup import unittest_setup
 
 class TestRoutingEntry(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_creating_new_routing_entry(self):
+    def test_creating_new_routing_entry(self) -> None:
         link_ids = list()
         proc_ids = list()
         for i in range(6):
@@ -44,7 +44,7 @@ class TestRoutingEntry(unittest.TestCase):
             pickle.loads(pickle.dumps(a_multicast, pickle.HIGHEST_PROTOCOL)))
         hash(a_multicast)
 
-    def test_defualtable_routing_entry(self):
+    def test_defualtable_routing_entry(self) -> None:
         a_multicast = RoutingEntry(
             processor_ids=[], link_ids=[4], incoming_link=1)
 
@@ -58,7 +58,7 @@ class TestRoutingEntry(unittest.TestCase):
             pickle.loads(pickle.dumps(a_multicast, pickle.HIGHEST_PROTOCOL)))
         hash(a_multicast)
 
-    def test_spinnaker_route(self):
+    def test_spinnaker_route(self) -> None:
         multicast1 = RoutingEntry(processor_ids=[1, 3, 4, 16],
                                   link_ids=[2, 3, 5])
         self.assertEqual(4196012, multicast1.spinnaker_route)
@@ -69,7 +69,7 @@ class TestRoutingEntry(unittest.TestCase):
         self.assertEqual(multicast3.link_ids, {2, 3, 5})
         self.assertEqual(multicast3.processor_ids, {1, 3, 4, 16})
 
-    def test_merger(self):
+    def test_merger(self) -> None:
         link_ids = list()
         link_ids2 = list()
         proc_ids = list()
@@ -99,7 +99,7 @@ class TestRoutingEntry(unittest.TestCase):
         self.assertEqual(result_multicast.processor_ids,
                          set(comparison_proc_ids))
 
-    def test_merger_with_different_defaultable(self):
+    def test_merger_with_different_defaultable(self) -> None:
         a_multicast = RoutingEntry(
             processor_ids=[], link_ids=[1], incoming_link=4)
         b_multicast = RoutingEntry(
@@ -114,7 +114,7 @@ class TestRoutingEntry(unittest.TestCase):
 
     """
     From FixedRouteEntry use or loose
-    def test_fixed_route_errors(self):
+    def test_fixed_route_errors(self) -> None:
         with self.assertRaises(SpinnMachineAlreadyExistsException) as e:
             FixedRouteEntry([1, 2, 2], [2, 3, 4])
         self.assertEqual(e.exception.item, "processor ID")

--- a/unittests/test_spinnaker_triad_geometry.py
+++ b/unittests/test_spinnaker_triad_geometry.py
@@ -19,10 +19,10 @@ from spinn_machine.config_setup import unittest_setup
 
 class TestingGeometry(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_geom(self):
+    def test_geom(self) -> None:
         # This table was produced using the code in Rig
         delta_table = [
             [(0, 0), (-1, 0), (-2, 0), (-3, 0), (-4, 0), (-1, -4),
@@ -60,7 +60,7 @@ class TestingGeometry(unittest.TestCase):
                     "x at ({},{}): expected ({},{}) but got ({},{})".format(
                         x, y, -px, -py, qx, qy))
 
-    def test_get_potential_ethernet_chips(self):
+    def test_get_potential_ethernet_chips(self) -> None:
         g = SpiNNakerTriadGeometry.get_spinn5_geometry()
         self.assertEqual(1, len(g.get_potential_ethernet_chips(2, 2)))
         self.assertEqual(1, len(g.get_potential_ethernet_chips(8, 8)))

--- a/unittests/test_using_virtual_machine.py
+++ b/unittests/test_using_virtual_machine.py
@@ -31,7 +31,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
 
     VERSION_5_N_CORES_PER_BOARD = sum(CHIPS_PER_BOARD.values())
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
     def _create_chip(self, x, y):
@@ -59,13 +59,15 @@ class TestUsingVirtualMachine(unittest.TestCase):
                         nearest_ethernet_chip[0],
                         nearest_ethernet_chip[1], None)
 
-    def test_new_vm_with_max_cores(self):
+    def test_new_vm_with_max_cores(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         version = MachineDataView.get_machine_version()
         n_cpus = version.max_cores_per_chip - 5
-        set_config("Machine", "max_machine_core", n_cpus)
+        set_config("Machine", "max_machine_core", str(n_cpus))
         # HACK Unsupported! Need new the version again after the cfg changed
-        MachineDataView._MachineDataView__data._machine_version = None
+        data = (MachineDataView.
+                _MachineDataView__data)    # type: ignore[attr-defined]
+        data._machine_version = None
         version = MachineDataView.get_machine_version()
         vm = virtual_machine_by_boards(1, validate=True)
         for chip in vm.chips:
@@ -78,7 +80,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
             self.assertEqual(version.n_scamp_cores,
                              len(list(chip.scamp_processors_ids)))
 
-    def test_iter_chips(self):
+    def test_iter_chips(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         vm = virtual_machine_by_boards(1)
         n_chips = MachineDataView.get_machine_version().n_chips_per_board
@@ -88,7 +90,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
             count += 1
         self.assertEqual(n_chips, count)
 
-    def test_down_chip(self):
+    def test_down_chip(self) -> None:
         set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
         down_chips = set()
         down_chips.add((1, 1))
@@ -107,7 +109,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
                       (source[1] + path[1] - path[2]) % height)
         self.assertEqual(target, new_target, "{}{}".format(source, path))
 
-    def test_nowrap_shortest_path(self):
+    def test_nowrap_shortest_path(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         machine = virtual_machine(16, 28, validate=True)
         for source in machine.chip_coordinates:
@@ -121,7 +123,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
                     mac_len, abs(path[0]) + abs(path[1]) + abs(path[2]))
                 self._check_path(source, target, path, 1000000, 1000000)
 
-    def test_fullwrap_shortest_path(self):
+    def test_fullwrap_shortest_path(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         width = 12
         height = 24
@@ -138,7 +140,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
                     "{}{}{}".format(source, target, path))
                 self._check_path(source, target, path, width, height)
 
-    def test_hoizontal_wrap_shortest_path(self):
+    def test_hoizontal_wrap_shortest_path(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         width = 12
         height = 16
@@ -163,7 +165,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
                     "{}{}{}".format(source, target, path))
                 self._check_path(source, target, path, width, height)
 
-    def test_vertical_wrap_shortest_path(self):
+    def test_vertical_wrap_shortest_path(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         width = 16
         height = 12
@@ -188,7 +190,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
                     "{}{}{}".format(source, target, path))
                 self._check_path(source, target, path, width, height)
 
-    def test_minimize(self):
+    def test_minimize(self) -> None:
         set_config("Machine", "versions", VersionStrings.ANY.text)
         machine = virtual_machine_by_boards(1)
         for x in range(-3, 3):
@@ -197,7 +199,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
                 min2 = machine._minimize_vector(x, y)
                 self.assertEqual(min1, min2)
 
-    def test_unreachable_incoming_chips(self):
+    def test_unreachable_incoming_chips(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine_by_min_size(6, 6)
 
@@ -210,7 +212,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
         unreachable = machine.unreachable_incoming_chips()
         self.assertListEqual([(3, 3)], unreachable)
 
-    def test_unreachable_outgoing_chips(self):
+    def test_unreachable_outgoing_chips(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine_by_min_size(6, 6)
 
@@ -221,7 +223,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
         unreachable = machine.unreachable_outgoing_chips()
         self.assertListEqual([(3, 3)], unreachable)
 
-    def test_unreachable_incoming_local_chips(self):
+    def test_unreachable_incoming_local_chips(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         # Assumes boards of exactly size 8,8
         down_chips = [(8, 6), (9, 7), (9, 8)]
@@ -231,7 +233,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
         unreachable = machine.unreachable_incoming_local_chips()
         self.assertListEqual([(8, 7)], unreachable)
 
-    def test_unreachable_outgoing_local_chips(self):
+    def test_unreachable_outgoing_local_chips(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         # Assumes boards of exactly size 8,8
         down_chips = [(8, 6), (9, 7), (9, 8)]
@@ -241,7 +243,7 @@ class TestUsingVirtualMachine(unittest.TestCase):
         unreachable = machine.unreachable_outgoing_local_chips()
         self.assertListEqual([(8, 7)], unreachable)
 
-    def test_repair_with_local_orphan(self):
+    def test_repair_with_local_orphan(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         # Assumes boards of exactly size 8,8
         down_chips = [(8, 6), (9, 7), (9, 8)]
@@ -249,14 +251,14 @@ class TestUsingVirtualMachine(unittest.TestCase):
         set_config("Machine", "down_chips", down_str)
         machine = virtual_machine(16, 16)
         with self.assertRaises(SpinnMachineException):
-            set_config("Machine", "repair_machine", False)
+            set_config("Machine", "repair_machine", "False")
             repaired = machine_repair(machine)
-        set_config("Machine", "repair_machine", True)
+        set_config("Machine", "repair_machine", "True")
         repaired = machine_repair(machine)
         self.assertTrue(machine.is_chip_at(8, 7))
         self.assertFalse(repaired.is_chip_at(8, 7))
 
-    def test_repair_with_one_way_links_different_boards(self):
+    def test_repair_with_one_way_links_different_boards(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         machine = virtual_machine(12, 12)
         # Assumes boards of exactly size 8,8
@@ -266,13 +268,13 @@ class TestUsingVirtualMachine(unittest.TestCase):
         for (x, y, link) in down_links:
             del machine._chips[x, y].router._links[link]
         with self.assertRaises(SpinnMachineException):
-            set_config("Machine", "repair_machine", False)
+            set_config("Machine", "repair_machine", "False")
             new_machine = machine_repair(machine)
-        set_config("Machine", "repair_machine", True)
+        set_config("Machine", "repair_machine", "True")
         new_machine = machine_repair(machine)
         self.assertIsNotNone(new_machine)
 
-    def test_oneway_link_no_repair(self):
+    def test_oneway_link_no_repair(self) -> None:
         set_config("Machine", "versions", VersionStrings.EIGHT_BY_EIGHT.text)
         machine = virtual_machine(8, 8)
 
@@ -283,23 +285,23 @@ class TestUsingVirtualMachine(unittest.TestCase):
             if machine.is_link_at(x, y, link):
                 del machine._chips[x, y].router._links[link]
         with self.assertRaises(SpinnMachineException):
-            set_config("Machine", "repair_machine", False)
+            set_config("Machine", "repair_machine", "False")
             new_machine = machine_repair(machine)
-        set_config("Machine", "repair_machine", True)
+        set_config("Machine", "repair_machine", "True")
         new_machine = machine_repair(machine)
         self.assertIsNotNone(new_machine)
 
-    def test_removed_chip_repair(self):
+    def test_removed_chip_repair(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine_by_boards(1)
 
         del machine._chips[(3, 3)]
-        set_config("Machine", "repair_machine", False)
+        set_config("Machine", "repair_machine", "False")
         new_machine = machine_repair(machine, [(3, 3)])
         self.assertIsNotNone(new_machine)
         self.assertFalse(new_machine.is_link_at(2, 2, 1))
 
-    def test_ignores(self):
+    def test_ignores(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         set_config("Machine", "down_chips", "2,2:4,4:6,6,ignored_ip")
         set_config("Machine", "down_cores",

--- a/unittests/test_version.py
+++ b/unittests/test_version.py
@@ -17,7 +17,7 @@ import spinn_machine
 from spinn_machine.config_setup import unittest_setup
 
 
-def test_compare_versions():
+def test_compare_versions() -> None:
     unittest_setup()
     spinn_utilities_parts = spinn_utilities.__version__.split('.')
     spinn_machine_parts = spinn_machine.__version__.split('.')

--- a/unittests/test_version_factory.py
+++ b/unittests/test_version_factory.py
@@ -23,68 +23,68 @@ from spinn_machine.version.version_factory import version_factory
 
 class TestVersionFactory(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_no_info(self):
+    def test_no_info(self) -> None:
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_bad_spalloc_3(self):
-        set_config("Machine", "version", 3)
+    def test_bad_spalloc_3(self) -> None:
+        set_config("Machine", "version", "3")
         set_config("Machine", "spalloc_server", "Somewhere")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_ok_spalloc_4(self):
-        set_config("Machine", "version", 4)
+    def test_ok_spalloc_4(self) -> None:
+        set_config("Machine", "version", "4")
         set_config("Machine", "spalloc_server", "Somewhere")
         version = version_factory()
         self.assertEqual(Version5(), version)
 
-    def test_ok_spalloc(self):
+    def test_ok_spalloc(self) -> None:
         # warning this behaviour may break if spalloc ever support spin2
         set_config("Machine", "spalloc_server", "Somewhere")
         version = version_factory()
         self.assertEqual(Version5(), version)
 
-    def test_ok_remote_5(self):
-        set_config("Machine", "version", 4)
+    def test_ok_remote_5(self) -> None:
+        set_config("Machine", "version", "4")
         set_config("Machine", "remote_spinnaker_url", "Somewhere")
         version = version_factory()
         self.assertEqual(Version5(), version)
 
-    def test_bad_spalloc_and_remote(self):
+    def test_bad_spalloc_and_remote(self) -> None:
         set_config("Machine", "spalloc_server", "Somewhere")
         set_config("Machine", "remote_spinnaker_url", "Somewhere")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_bad_spalloc_and_name(self):
+    def test_bad_spalloc_and_name(self) -> None:
         set_config("Machine", "spalloc_server", "Somewhere")
         set_config("Machine", "machine_name", "Somewhere")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_bad_spalloc_and_virtual(self):
+    def test_bad_spalloc_and_virtual(self) -> None:
         set_config("Machine", "spalloc_server", "Somewhere")
         set_config("Machine", "virtual_board", "True")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_bad_remote_and_name(self):
+    def test_bad_remote_and_name(self) -> None:
         set_config("Machine", "remote_spinnaker_url", "Somewhere")
         set_config("Machine", "machine_name", "Somewhere")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_bad_remote_and_virtual(self):
+    def test_bad_remote_and_virtual(self) -> None:
         set_config("Machine", "remote_spinnaker_url", "Somewhere")
         set_config("Machine", "virtual_board", "True")
         with self.assertRaises(SpinnMachineException):
             version_factory()
 
-    def test_bad_name_and_virtual(self):
+    def test_bad_name_and_virtual(self) -> None:
         set_config("Machine", "machine_name", "Somewhere")
         set_config("Machine", "virtual_board", "True")
         with self.assertRaises(SpinnMachineException):

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -28,7 +28,7 @@ from spinn_machine.virtual_machine import (
 
 class TestVirtualMachine201(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
     def _create_chip(self, x, y):
@@ -56,8 +56,8 @@ class TestVirtualMachine201(unittest.TestCase):
                         nearest_ethernet_chip[0],
                         nearest_ethernet_chip[1], None)
 
-    def test_illegal_vms(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_illegal_vms(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         with self.assertRaises(SpinnMachineException):
             virtual_machine(width=-1, height=2)
         with self.assertRaises(SpinnMachineException):
@@ -69,8 +69,8 @@ class TestVirtualMachine201(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             virtual_machine(width=2, height=2)
 
-    def test_version_SPIN2_1CHIP(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_version_SPIN2_1CHIP(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(width=1, height=1)
         self.assertEqual(1, vm.n_chips)
         self.assertTrue(vm.is_chip_at(0, 0))
@@ -91,17 +91,17 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertEqual(153, vm.get_cores_count())
         self.assertEqual(0, vm.get_links_count())
         count = 0
-        for _chip in vm.get_existing_xys_on_board(vm[0, 0]):
+        for _xy in vm.get_existing_xys_on_board(vm[0, 0]):
             count += 1
         self.assertEqual(1, count)
         self.assertEqual((1, 0), vm.get_unused_xy())
         self.assertEqual(0, len(list(vm.spinnaker_links)))
         self.assertEqual(0, len(vm._fpga_links))
 
-    def test_new_vm_with_max_cores(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_new_vm_with_max_cores(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         n_cpus = 105
-        set_config("Machine", "max_machine_core", n_cpus)
+        set_config("Machine", "max_machine_core", str(n_cpus))
         vm = virtual_machine(1, 1, validate=True)
         _chip = vm[0, 0]
         self.assertEqual(n_cpus, _chip.n_processors)
@@ -112,8 +112,8 @@ class TestVirtualMachine201(unittest.TestCase):
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 1 * n_cpus)
 
-    def test_iter_chips(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_iter_chips(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(1, 1)
         self.assertEqual(1, vm.n_chips)
         count = 0
@@ -121,23 +121,23 @@ class TestVirtualMachine201(unittest.TestCase):
             count += 1
         self.assertEqual(1, count)
 
-    def test_add_existing_chip(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_add_existing_chip(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(1, 1)
         _chip = self._create_chip(0, 0)
         with self.assertRaises(SpinnMachineAlreadyExistsException):
             vm.add_chip(_chip)
 
-    def test_chips(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_chips(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(1, 1)
         count = 0
         for _chip in vm.chips:
             count += 1
         self.assertEqual(count, 1)
 
-    def test_ethernet_chips_exist(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_ethernet_chips_exist(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(width=1, height=1)
         for eth_chip in vm._ethernet_connected_chips:
             self.assertTrue(vm.get_chip_at(eth_chip.x, eth_chip.y),
@@ -145,14 +145,14 @@ class TestVirtualMachine201(unittest.TestCase):
                             "_configured_chips"
                             .format(eth_chip.x, eth_chip.y))
 
-    def test_boot_chip(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_boot_chip(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(1, 1)
         # as Chip == its XY
         self.assertEqual(vm.boot_chip, (0, 0))
 
-    def test_get_chips_on_boards(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_get_chips_on_boards(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         vm = virtual_machine(width=1, height=1)
         # check each chip appears only once on the entire board
         count00 = 0
@@ -174,14 +174,14 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertEqual(count01, 0)
         self.assertEqual(count04, 0)
 
-    def test_fpga_links_single_board(self):
-        set_config("Machine", "version", 3)
+    def test_fpga_links_single_board(self) -> None:
+        set_config("Machine", "version", "3")
         machine = virtual_machine(width=2, height=2)
         machine.add_fpga_links()
         self.assertEqual(0, len(machine._fpga_links))
 
-    def test_size_2_2(self):
-        set_config("Machine", "version", 2)
+    def test_size_2_2(self) -> None:
+        set_config("Machine", "version", "2")
         machine = virtual_machine(2, 2, validate=True)
         ethernet = machine[0, 0]
         chips = set(machine.get_existing_xys_on_board(ethernet))
@@ -200,8 +200,8 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertEqual(len(global_xys), 4)
         self.assertEqual(4, len(list(machine.local_xys)))
 
-    def test_size_2_2_hole(self):
-        set_config("Machine", "version", 2)
+    def test_size_2_2_hole(self) -> None:
+        set_config("Machine", "version", "2")
         hole = [(1, 1)]
         set_config("Machine", "down_chips", "1,1")
         machine = virtual_machine(2, 2, validate=True)
@@ -223,8 +223,8 @@ class TestVirtualMachine201(unittest.TestCase):
                       (source[1] + path[1] - path[2]) % height)
         self.assertEqual(target, new_target, "{}{}".format(source, path))
 
-    def test_n_cores_2_2(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_n_cores_2_2(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         machine = virtual_machine(1, 1)
         n_cores = sum(
             cores for (_, cores) in machine.get_xy_cores_by_ethernet(0, 0))
@@ -232,8 +232,8 @@ class TestVirtualMachine201(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, 153)
 
-    def test_by(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_by(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         n_cores = 40
         machine = virtual_machine_by_cores(n_cores)
         self.assertEqual(1, machine.n_chips)
@@ -249,15 +249,15 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertEqual(1, machine.width)
         self.assertEqual(1, machine.height)
 
-    def test_by_cores_too_many(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_by_cores_too_many(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         with self.assertRaises(SpinnMachineException):
             virtual_machine_by_cores(200)
         with self.assertRaises(SpinnMachineException):
             virtual_machine_by_boards(2)
 
-    def test_down(self):
-        set_config("Machine", "version", SPIN2_1CHIP)
+    def test_down(self) -> None:
+        set_config("Machine", "version", str(SPIN2_1CHIP))
         set_config("Machine", "down_cores", "0,0,2.2.1")
         version = MachineDataView.get_machine_version()
         self.assertEqual(90, version.qx_qy_qp_to_id(2, 2, 1))

--- a/unittests/test_virtual_machine248.py
+++ b/unittests/test_virtual_machine248.py
@@ -26,11 +26,11 @@ class TestVirtualMachine248(unittest.TestCase):
 
     VERSION_248_N_CORES_PER_BOARD = sum(CHIPS_PER_BOARD.values())
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_illegal_vms(self):
-        set_config("Machine", "version", SPIN2_48CHIP)
+    def test_illegal_vms(self) -> None:
+        set_config("Machine", "version", str(SPIN2_48CHIP))
         with self.assertRaises(SpinnMachineException):
             virtual_machine(width=-1, height=2)
         with self.assertRaises(SpinnMachineException):
@@ -44,12 +44,12 @@ class TestVirtualMachine248(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             virtual_machine(size_x + 1, size_y, validate=True)
         size_x = 12 * 5
-        size_y = None
         with self.assertRaises(SpinnMachineException):
-            virtual_machine(size_x, size_y, validate=True)
+            virtual_machine(
+                size_x, None, validate=True)  # type: ignore[arg-type]
 
-    def test_version_248_8_by_8(self):
-        set_config("Machine", "version", SPIN2_48CHIP)
+    def test_version_248_8_by_8(self) -> None:
+        set_config("Machine", "version", str(SPIN2_48CHIP))
         vm = virtual_machine(width=8, height=8, validate=True)
         self.assertEqual(48, vm.n_chips)
         self.assertEqual(1, len(vm.ethernet_connected_chips))
@@ -147,8 +147,8 @@ class TestVirtualMachine248(unittest.TestCase):
         self.assertEqual(data, expected)
         """
 
-    def test_version_5_12_by_12(self):
-        set_config("Machine", "version", SPIN2_48CHIP)
+    def test_version_5_12_by_12(self) -> None:
+        set_config("Machine", "version", str(SPIN2_48CHIP))
         vm = virtual_machine(height=12, width=12, validate=True)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
@@ -170,8 +170,8 @@ class TestVirtualMachine248(unittest.TestCase):
         self.assertEqual(expected_fpgas, len(vm._fpga_links))
         """
 
-    def test_version_5_16_by_16(self):
-        set_config("Machine", "version", SPIN2_48CHIP)
+    def test_version_5_16_by_16(self) -> None:
+        set_config("Machine", "version", str(SPIN2_48CHIP))
         vm = virtual_machine(height=16, width=16, validate=True)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
@@ -208,7 +208,7 @@ class TestVirtualMachine248(unittest.TestCase):
         assert link.connected_chip_y == y
         assert link.connected_link == link_id
 
-    def test_fpga_links_single_board(self):
+    def test_fpga_links_single_board(self) -> None:
         set_config("Machine", "version", 5)
         machine = virtual_machine(width=8, height=8)
         machine.add_fpga_links()
@@ -266,7 +266,7 @@ class TestVirtualMachine248(unittest.TestCase):
         self._assert_fpga_link(machine, 2, 14, 7, 4, 0)
         self._assert_fpga_link(machine, 2, 15, 7, 3, 1)
 
-    def test_fpga_links_3_board(self):
+    def test_fpga_links_3_board(self) -> None:
         set_config("Machine", "version", 5)
         # A List of links, one for each side of each board in a 3-board toroid
         fpga_links = [("127.0.0.0", 0, 5, 5, 1, 5),

--- a/unittests/test_virtual_machine3.py
+++ b/unittests/test_virtual_machine3.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_machine import Chip, Link, Router, virtual_machine
@@ -26,7 +27,7 @@ from spinn_machine.virtual_machine import (
 
 class TestVirtualMachine3(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
     def _create_chip(self, x, y):
@@ -54,8 +55,8 @@ class TestVirtualMachine3(unittest.TestCase):
                         nearest_ethernet_chip[0],
                         nearest_ethernet_chip[1], None)
 
-    def test_illegal_vms(self):
-        set_config("Machine", "version", 3)
+    def test_illegal_vms(self) -> None:
+        set_config("Machine", "version", "3")
         with self.assertRaises(SpinnMachineException):
             virtual_machine(width=-1, height=2)
         with self.assertRaises(SpinnMachineException):
@@ -67,8 +68,8 @@ class TestVirtualMachine3(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             virtual_machine(width=1, height=1)
 
-    def test_version_2(self):
-        set_config("Machine", "version", 2)
+    def test_version_2(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(width=2, height=2)
         self.assertEqual(4, vm.n_chips)
         self.assertTrue(vm.is_chip_at(0, 0))
@@ -112,12 +113,12 @@ class TestVirtualMachine3(unittest.TestCase):
         self.assertEqual(72, vm.get_cores_count())
         self.assertEqual(8, vm.get_links_count())
         count = 0
-        for _chip in vm.get_existing_xys_on_board(vm[1, 1]):
+        for _xy in vm.get_existing_xys_on_board(vm[1, 1]):
             count += 1
         self.assertEqual(4, count)
         self.assertEqual((2, 0), vm.get_unused_xy())
         spinnaker_links = (list(vm.spinnaker_links))
-        expected = []
+        expected: List = []
         sp = SpinnakerLinkData(0, 0, 0, 3, '127.0.0.0')
         expected.append((('127.0.0.0', 0), sp))
         expected.append((((0, 0), 0), sp))
@@ -127,10 +128,10 @@ class TestVirtualMachine3(unittest.TestCase):
         self.assertEqual(expected, spinnaker_links)
         self.assertEqual(0, len(vm._fpga_links))
 
-    def test_new_vm_with_max_cores(self):
-        set_config("Machine", "version", 2)
+    def test_new_vm_with_max_cores(self) -> None:
+        set_config("Machine", "version", "2")
         n_cpus = 13
-        set_config("Machine", "max_machine_core", n_cpus)
+        set_config("Machine", "max_machine_core", str(n_cpus))
         vm = virtual_machine(2, 2, validate=True)
         _chip = vm[1, 1]
         self.assertEqual(n_cpus, _chip.n_processors)
@@ -141,8 +142,8 @@ class TestVirtualMachine3(unittest.TestCase):
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 4 * n_cpus)
 
-    def test_iter_chips(self):
-        set_config("Machine", "version", 2)
+    def test_iter_chips(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(2, 2)
         self.assertEqual(4, vm.n_chips)
         count = 0
@@ -150,8 +151,8 @@ class TestVirtualMachine3(unittest.TestCase):
             count += 1
         self.assertEqual(4, count)
 
-    def test_down_chip(self):
-        set_config("Machine", "version", 2)
+    def test_down_chip(self) -> None:
+        set_config("Machine", "version", "2")
         down_chips = set()
         down_chips.add((1, 1))
         set_config("Machine", "down_chips", "1,1")
@@ -163,23 +164,23 @@ class TestVirtualMachine3(unittest.TestCase):
             self.assertNotIn(_chip, down_chips)
         self.assertEqual(3, count)
 
-    def test_add_existing_chip(self):
-        set_config("Machine", "version", 2)
+    def test_add_existing_chip(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(2, 2)
         _chip = self._create_chip(1, 1)
         with self.assertRaises(SpinnMachineAlreadyExistsException):
             vm.add_chip(_chip)
 
-    def test_chips(self):
-        set_config("Machine", "version", 2)
+    def test_chips(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(2, 2)
         count = 0
         for _chip in vm.chips:
             count += 1
         self.assertEqual(count, 4)
 
-    def test_ethernet_chips_exist(self):
-        set_config("Machine", "version", 2)
+    def test_ethernet_chips_exist(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(width=2, height=2)
         for eth_chip in vm._ethernet_connected_chips:
             self.assertTrue(vm.get_chip_at(eth_chip.x, eth_chip.y),
@@ -187,14 +188,14 @@ class TestVirtualMachine3(unittest.TestCase):
                             "_configured_chips"
                             .format(eth_chip.x, eth_chip.y))
 
-    def test_boot_chip(self):
-        set_config("Machine", "version", 2)
+    def test_boot_chip(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(2, 2)
         # as Chip == its XY
         self.assertEqual(vm.boot_chip, (0, 0))
 
-    def test_get_chips_on_boards(self):
-        set_config("Machine", "version", 2)
+    def test_get_chips_on_boards(self) -> None:
+        set_config("Machine", "version", "2")
         vm = virtual_machine(width=2, height=2)
         # check each chip appears only once on the entire board
         count00 = 0
@@ -216,14 +217,14 @@ class TestVirtualMachine3(unittest.TestCase):
         # (24,36) is not on this virtual machine
         self.assertEqual(count04, 0)
 
-    def test_fpga_links_single_board(self):
-        set_config("Machine", "version", 3)
+    def test_fpga_links_single_board(self) -> None:
+        set_config("Machine", "version", "3")
         machine = virtual_machine(width=2, height=2)
         machine.add_fpga_links()
         self.assertEqual(0, len(machine._fpga_links))
 
-    def test_size_2_2(self):
-        set_config("Machine", "version", 2)
+    def test_size_2_2(self) -> None:
+        set_config("Machine", "version", "2")
         machine = virtual_machine(2, 2, validate=True)
         ethernet = machine[0, 0]
         chips = set(machine.get_existing_xys_on_board(ethernet))
@@ -242,8 +243,8 @@ class TestVirtualMachine3(unittest.TestCase):
         self.assertEqual(len(global_xys), 4)
         self.assertEqual(4, len(list(machine.local_xys)))
 
-    def test_size_2_2_hole(self):
-        set_config("Machine", "version", 2)
+    def test_size_2_2_hole(self) -> None:
+        set_config("Machine", "version", "2")
         hole = [(1, 1)]
         set_config("Machine", "down_chips", "1,1")
         machine = virtual_machine(2, 2, validate=True)
@@ -265,8 +266,8 @@ class TestVirtualMachine3(unittest.TestCase):
                       (source[1] + path[1] - path[2]) % height)
         self.assertEqual(target, new_target, "{}{}".format(source, path))
 
-    def test_n_cores_2_2(self):
-        set_config("Machine", "version", 2)
+    def test_n_cores_2_2(self) -> None:
+        set_config("Machine", "version", "2")
         machine = virtual_machine(2, 2)
         n_cores = sum(
             cores for (_, cores) in machine.get_xy_cores_by_ethernet(0, 0))
@@ -274,8 +275,8 @@ class TestVirtualMachine3(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, 4 * 18)
 
-    def test_2_2_by(self):
-        set_config("Machine", "version", 2)
+    def test_2_2_by(self) -> None:
+        set_config("Machine", "version", "2")
         n_cores = 40
         machine = virtual_machine_by_cores(n_cores)
         self.assertEqual(4, machine.n_chips)
@@ -291,8 +292,8 @@ class TestVirtualMachine3(unittest.TestCase):
         self.assertEqual(2, machine.width)
         self.assertEqual(2, machine.height)
 
-    def test_2_2_by_cores_too_many(self):
-        set_config("Machine", "version", 2)
+    def test_2_2_by_cores_too_many(self) -> None:
+        set_config("Machine", "version", "2")
         with self.assertRaises(SpinnMachineException):
             virtual_machine_by_cores(100)
         with self.assertRaises(SpinnMachineException):

--- a/unittests/test_virtual_machine5.py
+++ b/unittests/test_virtual_machine5.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List
 import unittest
 from spinn_utilities.config_holder import set_config
 
@@ -26,11 +27,11 @@ class TestVirtualMachine5(unittest.TestCase):
 
     VERSION_5_N_CORES_PER_BOARD = sum(CHIPS_PER_BOARD.values())
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_version_5(self):
-        set_config("Machine", "version", FIVE)
+    def test_version_5(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(width=8, height=8)
         self.assertEqual(48, vm.n_chips)
         self.assertEqual(1, len(vm.ethernet_connected_chips))
@@ -45,13 +46,13 @@ class TestVirtualMachine5(unittest.TestCase):
 #                         "[VirtualMachine: max_x=1, max_y=1, n_chips=4]")
         self.assertEqual(856, vm.get_cores_count())
         count = 0
-        for _chip in vm.get_existing_xys_on_board(vm[1, 1]):
+        for _xy in vm.get_existing_xys_on_board(vm[1, 1]):
             count += 1
         self.assertEqual(48, count)
         self.assertEqual((0, 4), vm.get_unused_xy())
 
-    def test_version_5_8_by_8(self):
-        set_config("Machine", "version", FIVE)
+    def test_version_5_8_by_8(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(width=8, height=8, validate=True)
         self.assertEqual(48, vm.n_chips)
         self.assertEqual(1, len(vm.ethernet_connected_chips))
@@ -63,7 +64,7 @@ class TestVirtualMachine5(unittest.TestCase):
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 856)
         spinnaker_links = (list(vm.spinnaker_links))
-        expected = []
+        expected: List = []
         sp = SpinnakerLinkData(0, 0, 0, 4, '127.0.0.0')
         expected.append((('127.0.0.0', 0), sp))
         expected.append((((0, 0), 0), sp))
@@ -125,7 +126,7 @@ class TestVirtualMachine5(unittest.TestCase):
         for (_, fpga_id, fpga_link), link in vm._fpga_links.items():
             data.add((link.connected_chip_x, link.connected_chip_y,
                       link.connected_link, fpga_id, fpga_link))
-        expected = set([(7, 3, 0, 0, 0), (7, 3, 5, 0, 1), (6, 2, 0, 0, 2),
+        expectes = set([(7, 3, 0, 0, 0), (7, 3, 5, 0, 1), (6, 2, 0, 0, 2),
                         (6, 2, 5, 0, 3), (5, 1, 0, 0, 4), (5, 1, 5, 0, 5),
                         (4, 0, 0, 0, 6), (4, 0, 5, 0, 7), (4, 0, 4, 0, 8),
                         (3, 0, 5, 0, 9), (3, 0, 4, 0, 10), (2, 0, 5, 0, 11),
@@ -143,10 +144,10 @@ class TestVirtualMachine5(unittest.TestCase):
                         (7, 6, 1, 2, 9), (7, 6, 0, 2, 10), (7, 5, 1, 2, 11),
                         (7, 5, 0, 2, 12), (7, 4, 1, 2, 13), (7, 4, 0, 2, 14),
                         (7, 3, 1, 2, 15)])
-        self.assertEqual(data, expected)
+        self.assertEqual(data, expectes)
 
-    def test_version_5_12_by_12(self):
-        set_config("Machine", "version", FIVE)
+    def test_version_5_12_by_12(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(height=12, width=12, validate=True)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
@@ -158,15 +159,15 @@ class TestVirtualMachine5(unittest.TestCase):
         self.assertEqual(48, count)
         self.assertEqual((12, 0), vm.get_unused_xy())
         spinnaker_links = (list(vm.spinnaker_links))
-        expected = []
+        expected: List = []
         self.assertEqual(expected, spinnaker_links)
         # 8 links on each of the 6 sides recorded 3 times
         # Except for the Ethernet Chip's 3 links which are only recorded twice
         expected_fpgas = (8 * 6 * 3 - 3) * 3
         self.assertEqual(expected_fpgas, len(vm._fpga_links))
 
-    def test_version_5_16_by_16(self):
-        set_config("Machine", "version", FIVE)
+    def test_version_5_16_by_16(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(height=16, width=16, validate=True)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
@@ -178,7 +179,7 @@ class TestVirtualMachine5(unittest.TestCase):
         self.assertEqual(48, count)
         self.assertEqual((0, 4), vm.get_unused_xy())
         spinnaker_links = (list(vm.spinnaker_links))
-        expected = []
+        expected: List = []
         sp = SpinnakerLinkData(0, 0, 0, 4, '127.0.0.0')
         expected.append((('127.0.0.0', 0), sp))
         expected.append((((0, 0), 0), sp))
@@ -198,8 +199,8 @@ class TestVirtualMachine5(unittest.TestCase):
         assert link.connected_chip_y == y
         assert link.connected_link == link_id
 
-    def test_fpga_links_single_board(self):
-        set_config("Machine", "version", FIVE)
+    def test_fpga_links_single_board(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         machine = virtual_machine(width=8, height=8)
         machine.add_fpga_links()
         self._assert_fpga_link(machine, 0, 0, 7, 3, 0)
@@ -256,8 +257,8 @@ class TestVirtualMachine5(unittest.TestCase):
         self._assert_fpga_link(machine, 2, 14, 7, 4, 0)
         self._assert_fpga_link(machine, 2, 15, 7, 3, 1)
 
-    def test_fpga_links_3_board(self):
-        set_config("Machine", "version", FIVE)
+    def test_fpga_links_3_board(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         # A List of links, one for each side of each board in a 3-board toroid
         fpga_links = [("127.0.0.0", 0, 5, 5, 1, 5),
                       ("127.0.0.0", 0, 12, 2, 0, 4),
@@ -286,8 +287,8 @@ class TestVirtualMachine5(unittest.TestCase):
         for ip, fpga, fpga_link, x, y, link in fpga_links:
             self._assert_fpga_link(machine, fpga, fpga_link, x, y, link, ip)
 
-    def test_none_triad(self):
-        set_config("Machine", "version", FIVE)
+    def test_none_triad(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         virtual_machine(width=20, height=16)
         virtual_machine(width=12, height=16)
 

--- a/unittests/test_virtual_machine_48chips.py
+++ b/unittests/test_virtual_machine_48chips.py
@@ -27,10 +27,10 @@ from spinn_machine.virtual_machine import (
 
 class TestVirtualMachine48Chips(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_illegal_vms(self):
+    def test_illegal_vms(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         with self.assertRaises(SpinnMachineException):
             virtual_machine(width=-1, height=2)
@@ -45,11 +45,11 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             virtual_machine(size_x + 1, size_y, validate=True)
         size_x = 12 * 5
-        size_y = None
         with self.assertRaises(SpinnMachineException):
-            virtual_machine(size_x, size_y, validate=True)
+            virtual_machine(size_x, None,  # type: ignore[arg-type]
+                            validate=True)
 
-    def test_version_hole(self):
+    def test_version_hole(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         set_config("Machine", "down_chips", "3,3")
         vm = virtual_machine(height=8, width=8, validate=True)
@@ -62,7 +62,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(228, count)
         self.assertEqual(48, len(list(vm.local_xys)))
 
-    def test_version_hole2(self):
+    def test_version_hole2(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         set_config("Machine", "down_chips", "0,3")
         vm = virtual_machine(height=8, width=8, validate=True)
@@ -76,21 +76,21 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(48, len(list(vm.local_xys)))
         self.assertEqual((0, 4), vm.get_unused_xy())
 
-    def test_12_n_plus4_12_m_4(self):
+    def test_12_n_plus4_12_m_4(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         size_x = 12 * 5
         size_y = 12 * 7
         vm = virtual_machine(size_x + 4, size_y + 4, validate=True)
         self.assertEqual(size_x * size_y, vm.n_chips)
 
-    def test_12_n_12_m(self):
+    def test_12_n_12_m(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         size_x = 12 * 5
         size_y = 12 * 7
         vm = virtual_machine(size_x, size_y, validate=True)
         self.assertEqual(size_x * size_y, vm.n_chips)
 
-    def test_chips(self):
+    def test_chips(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         vm = virtual_machine(8, 8)
         count = 0
@@ -98,7 +98,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
             count += 1
         self.assertEqual(count, 48)
 
-    def test_ethernet_chips_exist(self):
+    def test_ethernet_chips_exist(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         vm = virtual_machine(width=48, height=24)
         for eth_chip in vm._ethernet_connected_chips:
@@ -107,13 +107,13 @@ class TestVirtualMachine48Chips(unittest.TestCase):
                             "_configured_chips"
                             .format(eth_chip.x, eth_chip.y))
 
-    def test_boot_chip(self):
+    def test_boot_chip(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         vm = virtual_machine(12, 12)
         # based on Chip equaling its XY
         self.assertEqual(vm.boot_chip, (0, 0))
 
-    def test_get_chips_on_boards(self):
+    def test_get_chips_on_boards(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         vm = virtual_machine(width=24, height=36)
         # check each chip appears only once on the entire board
@@ -140,12 +140,12 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         # (24,36) is not on this virtual machine
         self.assertEqual(count2436, 0)
 
-    def test_big(self):
+    def test_big(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         virtual_machine(
             width=240, height=240, validate=True)
 
-    def test_48_28(self):
+    def test_48_28(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine(48, 24, validate=True)
         global_xys = set()
@@ -160,7 +160,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(len(global_xys), 48 * 24)
         self.assertEqual(48, len(list(machine.local_xys)))
 
-    def test_48_24(self):
+    def test_48_24(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine(48, 24, validate=True)
         global_xys = set()
@@ -175,7 +175,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(len(global_xys), 48 * 24)
         self.assertEqual(48, len(list(machine.local_xys)))
 
-    def test_52_28(self):
+    def test_52_28(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine(48, 24, validate=True)
         global_xys = set()
@@ -190,7 +190,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(len(global_xys), 48 * 24)
         self.assertEqual(48, len(list(machine.local_xys)))
 
-    def test_52_24(self):
+    def test_52_24(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine(48, 24, validate=True)
         global_xys = set()
@@ -205,7 +205,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(len(global_xys), 48 * 24)
         self.assertEqual(48, len(list(machine.local_xys)))
 
-    def test_fullwrap_holes(self):
+    def test_fullwrap_holes(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         hole = [(1, 1), (7, 7), (8, 1), (8, 10), (1, 8), (9, 6)]
         hole_str = ":".join([f"{x},{y}" for x, y in hole])
@@ -256,7 +256,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
             assert xy not in hole
         self.assertEqual(46, count)
 
-    def test_horizontal_wrap_holes(self):
+    def test_horizontal_wrap_holes(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         hole = [(1, 1), (7, 7), (8, 13), (8, 10), (1, 8), (9, 6)]
         hole_str = ":".join([f"{x},{y}" for x, y in hole])
@@ -307,7 +307,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
             assert xy not in hole
         self.assertEqual(46, count)
 
-    def test_vertical_wrap_holes(self):
+    def test_vertical_wrap_holes(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         hole = [(1, 1), (7, 7), (8, 1), (8, 10), (13, 8), (9, 6)]
         hole_str = ":".join([f"{x},{y}" for x, y in hole])
@@ -358,7 +358,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
             assert xy not in hole
         self.assertEqual(46, count)
 
-    def test_no_wrap_holes(self):
+    def test_no_wrap_holes(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         hole = [(1, 1), (7, 7), (8, 13), (8, 10), (13, 8), (9, 6)]
         hole_str = ":".join([f"{x},{y}" for x, y in hole])
@@ -409,7 +409,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
             assert xy not in hole
         self.assertEqual(46, count)
 
-    def test_n_cores_full_wrap(self):
+    def test_n_cores_full_wrap(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         cores_per_board = sum(version.chip_core_map.values())
@@ -421,7 +421,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, cores_per_board * 3)
 
-    def test_n_cores_no_wrap(self):
+    def test_n_cores_no_wrap(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         cores_per_board = sum(version.chip_core_map.values())
@@ -433,6 +433,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, cores_per_board * 3)
         chip34 = machine.get_chip_at(3, 4)
+        assert chip34 is not None
         where = machine.where_is_chip(chip34)
         self.assertEqual(
             where, 'global chip 3, 4 on 127.0.0.0 is chip 3, 4 on 127.0.0.0')
@@ -446,7 +447,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         where = machine.where_is_xy(15, 15)
         self.assertEqual(where, 'No chip 15, 15 found')
 
-    def test_n_cores_horizontal_wrap(self):
+    def test_n_cores_horizontal_wrap(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         cores_per_board = sum(version.chip_core_map.values())
@@ -458,7 +459,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, cores_per_board * 3)
 
-    def test_n_cores_vertical_wrap(self):
+    def test_n_cores_vertical_wrap(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         cores_per_board = sum(version.chip_core_map.values())
@@ -468,7 +469,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, cores_per_board * 3)
 
-    def test_n_cores_8_8(self):
+    def test_n_cores_8_8(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         cores_per_board = sum(version.chip_core_map.values())
@@ -479,7 +480,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         n_cores = sum(chip.n_processors for chip in machine.chips)
         self.assertEqual(n_cores, cores_per_board)
 
-    def test_8_8_by_cores_1_board(self):
+    def test_8_8_by_cores_1_board(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         n_cores = sum(version.chip_core_map.values())
@@ -493,7 +494,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(8, machine.height)
         self.assertEqual(n_cores, machine.total_available_user_cores)
 
-    def test_8_8_by_cores_3_boards(self):
+    def test_8_8_by_cores_3_boards(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         n_cores = sum(version.chip_core_map.values())
@@ -514,7 +515,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(16, machine.height)
         self.assertEqual(n_cores*3, machine.total_available_user_cores)
 
-    def test_8_8_by_cores_6_boards(self):
+    def test_8_8_by_cores_6_boards(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         n_cores = sum(version.chip_core_map.values())
@@ -528,7 +529,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(16, machine.height)
         self.assertEqual(n_cores * 6, machine.total_available_user_cores)
 
-    def test_8_8_by_cores_12_boards(self):
+    def test_8_8_by_cores_12_boards(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         n_cores = sum(version.chip_core_map.values())
@@ -542,7 +543,7 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(28, machine.height)
         self.assertEqual(n_cores * 12, machine.total_available_user_cores)
 
-    def test_8_8_by_cores_18_boards(self):
+    def test_8_8_by_cores_18_boards(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         n_cores = sum(version.chip_core_map.values())
@@ -556,13 +557,13 @@ class TestVirtualMachine48Chips(unittest.TestCase):
         self.assertEqual(28, machine.height)
         self.assertEqual(n_cores * 18, machine.total_available_user_cores)
 
-    def test_by_min_size(self):
+    def test_by_min_size(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         machine = virtual_machine_by_min_size(15, 21)
         self.assertGreaterEqual(machine.width, 15)
         self.assertGreaterEqual(machine.height, 21)
 
-    def test_by_min_size_edge_case(self):
+    def test_by_min_size_edge_case(self) -> None:
         set_config("Machine", "versions", VersionStrings.BIG.text)
         version = MachineDataView.get_machine_version()
         width, height = version.board_shape

--- a/unittests/version/test_version201.py
+++ b/unittests/version/test_version201.py
@@ -25,10 +25,10 @@ from spinn_machine.exceptions import SpinnMachineException
 
 class TestVersion201(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         version = Version201()
         self.assertEqual(153, version.max_cores_per_chip)
         self.assertEqual(2**30, version.max_sdram_per_chip)
@@ -39,30 +39,30 @@ class TestVersion201(unittest.TestCase):
         self.assertEqual(1, version.n_chips_per_board)
         self.assertEqual(16384, version.n_router_entries)
 
-    def test_verify_config_width_height(self):
+    def test_verify_config_width_height(self) -> None:
         set_config("Machine", "width", "None")
         set_config("Machine", "height", "None")
         Version201()
 
-        set_config("Machine", "width", 1)
+        set_config("Machine", "width", "1")
         with self.assertRaises(SpinnMachineException):
             Version201()
 
-        set_config("Machine", "height", 1)
+        set_config("Machine", "height", "1")
         Version201()
 
         set_config("Machine", "width", "None")
         with self.assertRaises(SpinnMachineException):
             Version201()
 
-    def test_set_max_lower(self):
-        set_config("Machine", "max_sdram_allowed_per_chip", 1000)
-        set_config("Machine", "max_machine_core", 100)
+    def test_set_max_lower(self) -> None:
+        set_config("Machine", "max_sdram_allowed_per_chip", "1000")
+        set_config("Machine", "max_machine_core", "100")
         version = Version201()
         self.assertEqual(100, version.max_cores_per_chip)
         self.assertEqual(1000, version.max_sdram_per_chip)
 
-    def test_expected_xys(self):
+    def test_expected_xys(self) -> None:
         version = Version201()
         xys = version.expected_xys
         self.assertEqual(1, len(xys))
@@ -73,7 +73,7 @@ class TestVersion201(unittest.TestCase):
             self.assertLess(x, 1)
             self.assertLess(y, 1)
 
-    def test_expected_chip_core_map(self):
+    def test_expected_chip_core_map(self) -> None:
         version = Version201()
         chip_core_map = version.chip_core_map
         self.assertEqual(1, len(chip_core_map))
@@ -86,20 +86,20 @@ class TestVersion201(unittest.TestCase):
             self.assertGreaterEqual(cores, 152)
             self.assertLessEqual(cores, 153)
 
-    def test_get_potential_ethernet_chips(self):
+    def test_get_potential_ethernet_chips(self) -> None:
         version = Version201()
         eths = version.get_potential_ethernet_chips(0, 0)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
 
         # if size is wromg GIGO
         eths = version.get_potential_ethernet_chips(8, 8)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
         eths = version.get_potential_ethernet_chips(12, 12)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
         eths = version.get_potential_ethernet_chips(16, 16)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
 
-    def test_verify_size(self):
+    def test_verify_size(self) -> None:
         version = Version201()
 
         with self.assertRaises(SpinnMachineException):
@@ -130,13 +130,13 @@ class TestVersion201(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             version.verify_size(16, 16)
 
-    def test_create_machine(self):
+    def test_create_machine(self) -> None:
         version = Version201()
 
         machine = version.create_machine(width=1, height=1)
         self.assertIsInstance(machine, NoWrapMachine)
 
-    def test_processor_info(self):
+    def test_processor_info(self) -> None:
         version = Version201()
         self.assertEqual([150, 300], version.clock_speeds_hz)
         # self.assertEqual(65536, version.dtcm_bytes)

--- a/unittests/version/test_version248.py
+++ b/unittests/version/test_version248.py
@@ -25,10 +25,10 @@ from spinn_machine.exceptions import SpinnMachineException
 
 class TestVersion201(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         version = Version248()
         self.assertEqual(153, version.max_cores_per_chip)
         self.assertEqual(2**30, version.max_sdram_per_chip)
@@ -39,30 +39,30 @@ class TestVersion201(unittest.TestCase):
         self.assertEqual(48, version.n_chips_per_board)
         self.assertEqual(16384, version.n_router_entries)
 
-    def test_verify_config_width_height(self):
+    def test_verify_config_width_height(self) -> None:
         set_config("Machine", "width", "None")
         set_config("Machine", "height", "None")
         Version248()
 
-        set_config("Machine", "width", 8)
+        set_config("Machine", "width", "8")
         with self.assertRaises(SpinnMachineException):
             Version248()
 
-        set_config("Machine", "height", 8)
+        set_config("Machine", "height", "8")
         Version248()
 
         set_config("Machine", "width", "None")
         with self.assertRaises(SpinnMachineException):
             Version248()
 
-    def test_set_max_lower(self):
-        set_config("Machine", "max_sdram_allowed_per_chip", 1000)
-        set_config("Machine", "max_machine_core", 100)
+    def test_set_max_lower(self) -> None:
+        set_config("Machine", "max_sdram_allowed_per_chip", "1000")
+        set_config("Machine", "max_machine_core", "100")
         version = Version248()
         self.assertEqual(100, version.max_cores_per_chip)
         self.assertEqual(1000, version.max_sdram_per_chip)
 
-    def test_expected_xys(self):
+    def test_expected_xys(self) -> None:
         version = Version248()
         xys = version.expected_xys
         self.assertEqual(48, len(xys))
@@ -73,7 +73,7 @@ class TestVersion201(unittest.TestCase):
             self.assertLess(x, 8)
             self.assertLess(y, 8)
 
-    def test_expected_chip_core_map(self):
+    def test_expected_chip_core_map(self) -> None:
         version = Version248()
         chip_core_map = version.chip_core_map
         self.assertEqual(48, len(chip_core_map))
@@ -86,19 +86,19 @@ class TestVersion201(unittest.TestCase):
             self.assertGreaterEqual(cores, 151)
             self.assertLessEqual(cores, 153)
 
-    def test_get_potential_ethernet_chips(self):
+    def test_get_potential_ethernet_chips(self) -> None:
         version = Version248()
         eths = version.get_potential_ethernet_chips(0, 0)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
 
         eths = version.get_potential_ethernet_chips(8, 8)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
         eths = version.get_potential_ethernet_chips(12, 12)
-        self.assertListEqual([(0, 0), (4, 8), (8, 4)], eths)
+        self.assertSequenceEqual([(0, 0), (4, 8), (8, 4)], eths)
         eths = version.get_potential_ethernet_chips(16, 16)
-        self.assertListEqual([(0, 0), (4, 8), (8, 4)], eths)
+        self.assertSequenceEqual([(0, 0), (4, 8), (8, 4)], eths)
 
-    def test_verify_size(self):
+    def test_verify_size(self) -> None:
         version = Version248()
 
         with self.assertRaises(SpinnMachineException):
@@ -131,13 +131,13 @@ class TestVersion201(unittest.TestCase):
         version.verify_size(16, 20)
         version.verify_size(20, 16)
 
-    def test_create_machine(self):
+    def test_create_machine(self) -> None:
         version = Version248()
 
         machine = version.create_machine(width=8, height=8)
         self.assertIsInstance(machine, NoWrapMachine)
 
-    def test_processor_info(self):
+    def test_processor_info(self) -> None:
         version = Version248()
         self.assertEqual([150, 300], version.clock_speeds_hz)
         # self.assertEqual(65536, version.dtcm_bytes)

--- a/unittests/version/test_version3.py
+++ b/unittests/version/test_version3.py
@@ -25,10 +25,10 @@ from spinn_machine.exceptions import SpinnMachineException
 
 class TestVersion3(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         version = Version3()
         self.assertEqual(18, version.max_cores_per_chip)
         self.assertEqual(123469792, version.max_sdram_per_chip)
@@ -39,30 +39,30 @@ class TestVersion3(unittest.TestCase):
         self.assertEqual(4, version.n_chips_per_board)
         self.assertEqual(1023, version.n_router_entries)
 
-    def test_verify_config_width_height(self):
+    def test_verify_config_width_height(self) -> None:
         set_config("Machine", "width", "None")
         set_config("Machine", "height", "None")
         Version3()
 
-        set_config("Machine", "width", 2)
+        set_config("Machine", "width", "2")
         with self.assertRaises(SpinnMachineException):
             Version3()
 
-        set_config("Machine", "height", 2)
+        set_config("Machine", "height", "2")
         Version3()
 
         set_config("Machine", "width", "None")
         with self.assertRaises(SpinnMachineException):
             Version3()
 
-    def test_set_max_lower(self):
-        set_config("Machine", "max_sdram_allowed_per_chip", 1000)
-        set_config("Machine", "max_machine_core", 10)
+    def test_set_max_lower(self) -> None:
+        set_config("Machine", "max_sdram_allowed_per_chip", "1000")
+        set_config("Machine", "max_machine_core", "10")
         version = Version3()
         self.assertEqual(10, version.max_cores_per_chip)
         self.assertEqual(1000, version.max_sdram_per_chip)
 
-    def test_expected_xys(self):
+    def test_expected_xys(self) -> None:
         version = Version3()
         xys = version.expected_xys
         self.assertEqual(4, len(xys))
@@ -73,7 +73,7 @@ class TestVersion3(unittest.TestCase):
             self.assertLess(x, 2)
             self.assertLess(y, 2)
 
-    def test_expected_chip_core_map(self):
+    def test_expected_chip_core_map(self) -> None:
         version = Version3()
         chip_core_map = version.chip_core_map
         self.assertEqual(4, len(chip_core_map))
@@ -86,20 +86,20 @@ class TestVersion3(unittest.TestCase):
             self.assertGreaterEqual(cores, 16)
             self.assertLessEqual(cores, 18)
 
-    def test_get_potential_ethernet_chips(self):
+    def test_get_potential_ethernet_chips(self) -> None:
         version = Version3()
         eths = version.get_potential_ethernet_chips(2, 2)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
 
         # if size is wromg GIGO
         eths = version.get_potential_ethernet_chips(8, 8)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
         eths = version.get_potential_ethernet_chips(12, 12)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
         eths = version.get_potential_ethernet_chips(16, 16)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
 
-    def test_verify_size(self):
+    def test_verify_size(self) -> None:
         version = Version3()
 
         with self.assertRaises(SpinnMachineException):
@@ -128,25 +128,25 @@ class TestVersion3(unittest.TestCase):
         with self.assertRaises(SpinnMachineException):
             version.verify_size(16, 16)
 
-    def test_create_machin(self):
+    def test_create_machin(self) -> None:
         version = Version3()
 
         machine = version.create_machine(width=2, height=2)
         self.assertIsInstance(machine, FullWrapMachine)
 
-    def test_processor_info(self):
+    def test_processor_info(self) -> None:
         version = Version3()
         self.assertEqual([200], version.clock_speeds_hz)
         self.assertEqual(65536, version.dtcm_bytes)
 
-    def test_size_from_n_cores(self):
+    def test_size_from_n_cores(self) -> None:
         version = Version3()
         self.assertEqual((2, 2), version.size_from_n_cores(10))
         self.assertEqual((2, 2), version.size_from_n_cores(17 * 4))
         with self.assertRaises(SpinnMachineException):
             version.size_from_n_cores(17 * 4 + 1)
 
-    def test_size_from_n_chips(self):
+    def test_size_from_n_chips(self) -> None:
         version = Version3()
         self.assertEqual((2, 2), version.size_from_n_chips(1))
         self.assertEqual((2, 2), version.size_from_n_chips(4))

--- a/unittests/version/test_version5.py
+++ b/unittests/version/test_version5.py
@@ -28,10 +28,10 @@ from spinn_machine.exceptions import SpinnMachineException
 
 class TestVersion5(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_attributes(self):
+    def test_attributes(self) -> None:
         version = Version5()
         self.assertEqual(18, version.max_cores_per_chip)
         self.assertEqual(123469792, version.max_sdram_per_chip)
@@ -42,30 +42,30 @@ class TestVersion5(unittest.TestCase):
         self.assertEqual(48, version.n_chips_per_board)
         self.assertEqual(1023, version.n_router_entries)
 
-    def test_verify_config_width_height(self):
+    def test_verify_config_width_height(self) -> None:
         set_config("Machine", "width", "None")
         set_config("Machine", "height", "None")
         Version5()
 
-        set_config("Machine", "width", 8)
+        set_config("Machine", "width", "8")
         with self.assertRaises(SpinnMachineException):
             Version5()
 
-        set_config("Machine", "height", 8)
+        set_config("Machine", "height", "8")
         Version5()
 
         set_config("Machine", "width", "None")
         with self.assertRaises(SpinnMachineException):
             Version5()
 
-    def test_set_max_lower(self):
-        set_config("Machine", "max_sdram_allowed_per_chip", 1000)
-        set_config("Machine", "max_machine_core", 10)
+    def test_set_max_lower(self) -> None:
+        set_config("Machine", "max_sdram_allowed_per_chip", "1000")
+        set_config("Machine", "max_machine_core", "10")
         version = Version5()
         self.assertEqual(10, version.max_cores_per_chip)
         self.assertEqual(1000, version.max_sdram_per_chip)
 
-    def test_expected_xys(self):
+    def test_expected_xys(self) -> None:
         version = Version5()
         xys = version.expected_xys
         self.assertEqual(48, len(xys))
@@ -76,7 +76,7 @@ class TestVersion5(unittest.TestCase):
             self.assertLess(x, 8)
             self.assertLess(y, 8)
 
-    def test_expected_chip_core_map(self):
+    def test_expected_chip_core_map(self) -> None:
         version = Version5()
         chip_core_map = version.chip_core_map
         self.assertEqual(48, len(chip_core_map))
@@ -89,20 +89,20 @@ class TestVersion5(unittest.TestCase):
             self.assertGreaterEqual(cores, 16)
             self.assertLessEqual(cores, 18)
 
-    def test_get_potential_ethernet_chips(self):
+    def test_get_potential_ethernet_chips(self) -> None:
         version = Version5()
         eths = version.get_potential_ethernet_chips(8, 8)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
         eths = version.get_potential_ethernet_chips(12, 12)
-        self.assertListEqual([(0, 0), (4, 8), (8, 4)], eths)
+        self.assertSequenceEqual([(0, 0), (4, 8), (8, 4)], eths)
         eths = version.get_potential_ethernet_chips(16, 16)
-        self.assertListEqual([(0, 0), (4, 8), (8, 4)], eths)
+        self.assertSequenceEqual([(0, 0), (4, 8), (8, 4)], eths)
 
         # if size is wrong GIGO
         eths = version.get_potential_ethernet_chips(2, 2)
-        self.assertListEqual([(0, 0)], eths)
+        self.assertSequenceEqual([(0, 0)], eths)
 
-    def test_verify_size(self):
+    def test_verify_size(self) -> None:
         version = Version5()
 
         with self.assertRaises(SpinnMachineException):
@@ -128,7 +128,7 @@ class TestVersion5(unittest.TestCase):
         version.verify_size(16, 12)
         version.verify_size(16, 16)
 
-    def test_create_machin(self):
+    def test_create_machin(self) -> None:
         version = Version5()
 
         machine = version.create_machine(width=8, height=8)
@@ -144,12 +144,12 @@ class TestVersion5(unittest.TestCase):
         machine = version.create_machine(12, 12)
         self.assertIsInstance(machine, FullWrapMachine)
 
-    def test_processor_info(self):
+    def test_processor_info(self) -> None:
         version = Version5()
         self.assertEqual([200], version.clock_speeds_hz)
         self.assertEqual(65536, version.dtcm_bytes)
 
-    def test_size_from_n_cores(self):
+    def test_size_from_n_cores(self) -> None:
         version = Version5()
         self.assertEqual((8, 8), version.size_from_n_cores(10))
         # standard for there to be 8 17 core Chips and each has 1 scamp core
@@ -165,7 +165,7 @@ class TestVersion5(unittest.TestCase):
         self.assertEqual((40, 28), version.size_from_n_cores(n_cores * 18))
         self.assertEqual((40, 40), version.size_from_n_cores(n_cores * 18 + 1))
 
-    def test_size_from_n_chips(self):
+    def test_size_from_n_chips(self) -> None:
         version = Version5()
         self.assertEqual((8, 8), version.size_from_n_chips(1))
         self.assertEqual((8, 8), version.size_from_n_chips(48))

--- a/unittests/version/test_version_string.py
+++ b/unittests/version/test_version_string.py
@@ -23,10 +23,10 @@ from spinn_machine.version.version_strings import VersionStrings
 
 class TestVersionString(unittest.TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         unittest_setup()
 
-    def test_names(self):
+    def test_names(self) -> None:
         vs = VersionStrings.from_string("any")
         self.assertEqual(vs.text, "Any")
         vs = VersionStrings.from_string("FourPlus")


### PR DESCRIPTION
typing of unit tests

set_config calls changed to str as the underlying config code expects Optional[str]


