### PR TITLE
cfg machine_name

### DIFF
--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -106,7 +106,7 @@ def _get_url_version() -> Optional[int]:
     spalloc_server = get_config_str_or_none("Machine", "spalloc_server")
     remote_spinnaker_url = get_config_str_or_none(
         "Machine", "remote_spinnaker_url")
-    machine_name = get_config_str_or_none("Machine", "machineName")
+    machine_name = get_config_str_or_none("Machine", "machine_name")
     virtual_board = get_config_bool("Machine", "virtual_board")
 
     if spalloc_server is not None:
@@ -198,7 +198,7 @@ def raise_version_error(error: str, version: Optional[int]) -> Never:
                                             "spalloc_server")
     remote_spinnaker_url = get_config_str_or_none(
         "Machine", "remote_spinnaker_url")
-    machine_name = get_config_str_or_none("Machine", "machineName")
+    machine_name = get_config_str_or_none("Machine", "machine_name")
     virtual_board = get_config_bool("Machine", "virtual_board")
     raise SpinnMachineException(
         f"{error} with cfg [Machine] values {version=}, "

--- a/unittests/data/test_data.py
+++ b/unittests/data/test_data.py
@@ -188,7 +188,7 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(3, MachineDataView.get_ethernet_monitor_cores())
 
     def test_no_version(self) -> None:
-        set_config("Machine", "machineName", "SpiNNaker1M")
+        set_config("Machine", "machine_name", "SpiNNaker1M")
         try:
             MachineDataView.get_machine_version()
             raise ConfigException("Should not get here")

--- a/unittests/test_cfg_checker.py
+++ b/unittests/test_cfg_checker.py
@@ -14,7 +14,7 @@
 
 import os
 import unittest
-from spinn_utilities.config_holder import run_config_checks
+from spinn_utilities.configs.config_checker import ConfigChecker
 import spinn_machine
 from spinn_machine.config_setup import unittest_setup
 
@@ -27,4 +27,4 @@ class TestCfgChecker(unittest.TestCase):
     def test_cfg_checker(self) -> None:
         unittests_dir = os.path.dirname(__file__)
         spinn_machine_dir = spinn_machine.__path__[0]
-        run_config_checks(directories=[spinn_machine_dir, unittests_dir])
+        ConfigChecker([spinn_machine_dir, unittests_dir]).check()


### PR DESCRIPTION
needed for 
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1276
or more specifcally:
https://github.com/SpiNNakerManchester/SpiNNUtils/pull/297

As the cfg checker now when checking requires exact match.

Normal runs would still work without these changes,

But makes it easier to find the usage of cfg values like machine_name