### PR TITLE
Energy cleanup

### DIFF
--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -688,6 +688,13 @@ class Machine(object, metaclass=AbstractBase):
         return self._ethernet_connected_chips
 
     @property
+    def n_ethernet_connected_chips(self) -> int:
+        """
+        The number of chips in the machine that have an Ethernet connection.
+        """
+        return len(self._ethernet_connected_chips)
+
+    @property
     def spinnaker_links(self) -> Iterator[
             Tuple[_SpinLinkKey, SpinnakerLinkData]]:
         """

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -528,7 +528,8 @@ class AbstractVersion(object, metaclass=AbstractBase):
         :param n_frames: The number of frames
         :param n_boards: The number of boards
         :param n_chips: The number of chips
-        :param sum_chip_active_time: Sum of times the cores were active in seconds
+        :param sum_chip_active_time:
+            Sum of times the cores were active in seconds
         :param router_packets: The number of packets sent by each router
         :returns: the active energy consumption of the system in joules
         """

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -31,8 +31,6 @@ logger = FormatAdapter(logging.getLogger(__name__))
 
 # Dict of the number of packets sent by each router in each category
 RouterPackets: TypeAlias = Dict[XY, Dict[str, int]]
-# Dict of the time the cores were active in seconds, and the number of cores
-ChipActiveTime: TypeAlias = Dict[XY, Tuple[float, int]]
 
 CORE_RANGE = re.compile(r"(\d+)-(\d+)")
 CORE_SINGLE = re.compile(r"(-*)(\d+)")
@@ -523,14 +521,14 @@ class AbstractVersion(object, metaclass=AbstractBase):
     @abstractmethod
     def get_active_energy(
             self, time_s: float, n_frames: int, n_boards: int, n_chips: int,
-            chip_active_time: ChipActiveTime,
+            sum_chip_active_time: float,
             router_packets: RouterPackets) -> float:
         """
         :param time_s: The time to calculate the energy for in seconds
         :param n_frames: The number of frames
         :param n_boards: The number of boards
         :param n_chips: The number of chips
-        :param chip_active_time: The time the cores were active in seconds
+        :param sum_chip_active_time: Sum of times the cores were active in seconds
         :param router_packets: The number of packets sent by each router
         :returns: the active energy consumption of the system in joules
         """

--- a/spinn_machine/version/version_3.py
+++ b/spinn_machine/version/version_3.py
@@ -19,7 +19,7 @@ from spinn_machine.exceptions import SpinnMachineException
 from spinn_machine.full_wrap_machine import FullWrapMachine
 from spinn_machine.machine import Machine
 from .version_spin1 import VersionSpin1
-from .abstract_version import ChipActiveTime, RouterPackets
+from .abstract_version import RouterPackets
 
 CHIPS_PER_BOARD: Final = {(0, 0): 18, (0, 1): 18, (1, 0): 18, (1, 1): 18}
 
@@ -110,12 +110,12 @@ class Version3(VersionSpin1):
     @overrides(VersionSpin1.get_active_energy)
     def get_active_energy(
             self, time_s: float, n_frames: int, n_boards: int, n_chips: int,
-            chip_active_time: ChipActiveTime,
+            sum_chip_active_time: float,
             router_packets: RouterPackets) -> float:
         return (
             self.get_idle_energy(time_s, n_frames, n_boards, n_chips) +
             self._get_router_active_energy(router_packets) +
-            self._get_core_active_energy(chip_active_time))
+            self._get_core_active_energy(sum_chip_active_time))
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Version3)

--- a/spinn_machine/version/version_5.py
+++ b/spinn_machine/version/version_5.py
@@ -18,7 +18,7 @@ from spinn_utilities.typing.coords import XY
 
 from .version_48_chips import Version48Chips
 from .version_spin1 import VersionSpin1
-from .abstract_version import ChipActiveTime, RouterPackets
+from .abstract_version import RouterPackets
 
 CHIPS_PER_BOARD: Final = {
     (0, 0): 18, (0, 1): 18, (0, 2): 18, (0, 3): 18, (1, 0): 18, (1, 1): 17,
@@ -132,7 +132,7 @@ class Version5(VersionSpin1, Version48Chips):
     @overrides(VersionSpin1.get_active_energy)
     def get_active_energy(
             self, time_s: float, n_frames: int, n_boards: int, n_chips: int,
-            chip_active_time: ChipActiveTime,
+            sum_chip_active_time: float,
             router_packets: RouterPackets) -> float:
         container_energy = 0.0
         if n_frames != 0:
@@ -142,7 +142,7 @@ class Version5(VersionSpin1, Version48Chips):
             container_energy +
             self.get_idle_energy(time_s, n_frames, n_boards, n_chips) +
             self._get_router_active_energy(router_packets) +
-            self._get_core_active_energy(chip_active_time))
+            self._get_core_active_energy(sum_chip_active_time))
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Version5)

--- a/spinn_machine/version/version_spin1.py
+++ b/spinn_machine/version/version_spin1.py
@@ -18,8 +18,7 @@ from spinn_utilities.exceptions import ConfigException
 from spinn_utilities.overrides import overrides
 
 from spinn_machine.exceptions import SpinnMachineException
-from .abstract_version import (
-    AbstractVersion, RouterPackets, ChipActiveTime)
+from .abstract_version import (AbstractVersion, RouterPackets)
 
 
 class VersionSpin1(AbstractVersion, metaclass=AbstractBase):
@@ -123,9 +122,5 @@ class VersionSpin1(AbstractVersion, metaclass=AbstractBase):
             for name, value in packets.items())
 
     def _get_core_active_energy(
-            self, core_active_times: ChipActiveTime) -> float:
-        # TODO: treat cores that are active sometimes differently to cores that
-        # are always idle
-        return sum(
-            time * self.WATTS_PER_CORE_ACTIVE_OVERHEAD
-            for time, _n_cores in core_active_times.values())
+            self, sum_core_active_times: float) -> float:
+        return sum_core_active_times * self.WATTS_PER_CORE_ACTIVE_OVERHEAD

--- a/spinn_machine/version/version_spin2.py
+++ b/spinn_machine/version/version_spin2.py
@@ -20,8 +20,7 @@ from spinn_utilities.exceptions import ConfigException
 from spinn_utilities.overrides import overrides
 
 from spinn_machine.exceptions import SpinnMachineException
-from .abstract_version import (
-    AbstractVersion, ChipActiveTime, RouterPackets)
+from .abstract_version import (AbstractVersion, RouterPackets)
 
 CHIPS_PER_BOARD: Final = {(0, 0): 152}
 CORE_QX_QY_QP = re.compile(r"(\d)\.(\d)\.(\d)")
@@ -139,7 +138,7 @@ class VersionSpin2(AbstractVersion, metaclass=AbstractBase):
     @overrides(AbstractVersion.get_active_energy)
     def get_active_energy(
             self, time_s: float, n_frames: int, n_boards: int, n_chips: int,
-            chip_active_time: ChipActiveTime,
+            sum_chip_active_time: float,
             router_packets: RouterPackets) -> float:
         # TODO: Work this out for SpiNNaker 2
         raise SpinnMachineException("Spin2 active energy unknown.")

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -76,7 +76,7 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertTrue(vm.is_chip_at(0, 0))
         self.assertFalse(vm.is_chip_at(0, 1))
         self.assertEqual(1, len(vm.ethernet_connected_chips))
-        self.assertEqual(1, vm.n_.ethernet_connected_chips)
+        self.assertEqual(1, vm.n_ethernet_connected_chips)
         self.assertFalse(vm.is_link_at(0, 0, 0))
         self.assertFalse(vm.is_link_at(0, 0, 1))
         self.assertFalse(vm.is_link_at(0, 0, 2))

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -76,6 +76,7 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertTrue(vm.is_chip_at(0, 0))
         self.assertFalse(vm.is_chip_at(0, 1))
         self.assertEqual(1, len(vm.ethernet_connected_chips))
+        self.assertEqual(1, vm.n_.ethernet_connected_chips)
         self.assertFalse(vm.is_link_at(0, 0, 0))
         self.assertFalse(vm.is_link_at(0, 0, 1))
         self.assertFalse(vm.is_link_at(0, 0, 2))

--- a/unittests/test_virtual_machine248.py
+++ b/unittests/test_virtual_machine248.py
@@ -152,6 +152,7 @@ class TestVirtualMachine248(unittest.TestCase):
         vm = virtual_machine(height=12, width=12, validate=True)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
+        self.assertEqual(3, vm.n_ethernet_connected_chips)
         count = sum(1 for _chip in vm.chips for _link in _chip.router.links)
         self.assertEqual(864, count)
         count = 0


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1353

includes https://github.com/SpiNNakerManchester/SpiNNMachine/pull/307

adds a n_ethernet_connected_chips property to Machine

simplifes get_active_energy to just get a total of runtimes on all cores
rather than a dict of total by chip
As it just sums the values anyway