### PR TITLE
remove MAX_CORES_PER_ROUTER use max_cores

### DIFF
--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -14,6 +14,9 @@
 from __future__ import annotations
 from typing import (
     Dict, Iterable, Iterator, List, Optional, Tuple, Union, TYPE_CHECKING)
+
+from spinn_machine.data import MachineDataView
+
 from .exceptions import (
     SpinnMachineAlreadyExistsException, SpinnMachineInvalidParameterException)
 if TYPE_CHECKING:
@@ -37,8 +40,6 @@ class Router(object):
 
     # Number to add or sub from a link to get its opposite
     LINK_OPPOSITE = 3
-
-    MAX_CORES_PER_ROUTER = 18
 
     __slots__ = ("_links", "_n_available_multicast_entries")
 
@@ -148,13 +149,14 @@ class Router(object):
             of all chip links and core links.
         """
         route_entry = 0
+        max_cores = MachineDataView.get_machine_version().max_cores_per_chip
         for processor_id in routing_table_entry.processor_ids:
-            if processor_id >= Router.MAX_CORES_PER_ROUTER or processor_id < 0:
+            if 0 > processor_id >= max_cores:
                 raise SpinnMachineInvalidParameterException(
                     "route.processor_ids",
                     str(routing_table_entry.processor_ids),
                     "Processor IDs must be between 0 and " +
-                    str(Router.MAX_CORES_PER_ROUTER - 1))
+                    str(max_cores - 1))
             route_entry |= (1 << (Router.MAX_LINKS_PER_ROUTER + processor_id))
         for link_id in routing_table_entry.link_ids:
             if link_id >= Router.MAX_LINKS_PER_ROUTER or link_id < 0:
@@ -175,7 +177,8 @@ class Router(object):
         :param route: The routing table entry
         :return: The list of processor IDs, and the list of link IDs.
         """
-        processor_ids = [pi for pi in range(0, Router.MAX_CORES_PER_ROUTER)
+        max_cores = MachineDataView.get_machine_version().max_cores_per_chip
+        processor_ids = [pi for pi in range(0, max_cores)
                          if route & 1 << (Router.MAX_LINKS_PER_ROUTER + pi)]
         link_ids = [li for li in range(0, Router.MAX_LINKS_PER_ROUTER)
                     if route & 1 << li]

--- a/spinn_machine/routing_entry.py
+++ b/spinn_machine/routing_entry.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import (Any, Collection, FrozenSet, Optional, overload, Tuple,
                     Union)
 from spinn_machine.router import Router
+from .data import MachineDataView
 from .exceptions import (SpinnMachineInvalidParameterException)
 
 
@@ -215,7 +216,8 @@ class RoutingEntry(object):
         Convert a binary routing table entry usable on the machine to lists of
         route IDs usable in a routing table entry represented in software.
         """
-        processor_ids = (pi for pi in range(0, Router.MAX_CORES_PER_ROUTER)
+        max_cores = MachineDataView.get_machine_version().max_cores_per_chip
+        processor_ids = (pi for pi in range(0, max_cores)
                          if self._spinnaker_route & 1 <<
                          (Router.MAX_LINKS_PER_ROUTER + pi))
         link_ids = (li for li in range(0, Router.MAX_LINKS_PER_ROUTER)

--- a/unittests/test_multicast_routing_entry.py
+++ b/unittests/test_multicast_routing_entry.py
@@ -15,9 +15,13 @@
 import pickle
 from typing import List
 import unittest
+
+from spinn_utilities.config_holder import set_config
+
 from spinn_machine import MulticastRoutingEntry, RoutingEntry
 from spinn_machine.config_setup import unittest_setup
 from spinn_machine.exceptions import SpinnMachineInvalidParameterException
+from spinn_machine.version import FIVE
 
 
 class TestMulticastRoutingEntry(unittest.TestCase):
@@ -80,6 +84,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
             MulticastRoutingEntry(1, 2, None)  # type: ignore[arg-type]
 
     def test_spinnaker_route(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         multicast1 = MulticastRoutingEntry(1, 1, RoutingEntry(
             processor_ids=[1, 3, 4, 16], link_ids=[2, 3, 5]))
         self.assertEqual(4196012, multicast1.spinnaker_route)
@@ -93,6 +98,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
         self.assertEqual(multicast3.processor_ids, {1, 3, 4, 16})
 
     def test_merger(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         link_ids = list()
         link_ids2 = list()
         proc_ids = list()
@@ -131,6 +137,7 @@ class TestMulticastRoutingEntry(unittest.TestCase):
                          set(comparison_proc_ids))
 
     def test_merger_with_different_defaultable(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         key = 1
         mask = 1
         a_multicast = MulticastRoutingEntry(key, mask, RoutingEntry(

--- a/unittests/test_routing_entry.py
+++ b/unittests/test_routing_entry.py
@@ -14,8 +14,12 @@
 
 import pickle
 import unittest
+
+from spinn_utilities.config_holder import set_config
+
 from spinn_machine import RoutingEntry
 from spinn_machine.config_setup import unittest_setup
+from spinn_machine.version import FIVE
 
 
 class TestRoutingEntry(unittest.TestCase):
@@ -59,6 +63,7 @@ class TestRoutingEntry(unittest.TestCase):
         hash(a_multicast)
 
     def test_spinnaker_route(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         multicast1 = RoutingEntry(processor_ids=[1, 3, 4, 16],
                                   link_ids=[2, 3, 5])
         self.assertEqual(4196012, multicast1.spinnaker_route)
@@ -70,6 +75,7 @@ class TestRoutingEntry(unittest.TestCase):
         self.assertEqual(multicast3.processor_ids, {1, 3, 4, 16})
 
     def test_merger(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         link_ids = list()
         link_ids2 = list()
         proc_ids = list()
@@ -100,6 +106,7 @@ class TestRoutingEntry(unittest.TestCase):
                          set(comparison_proc_ids))
 
     def test_merger_with_different_defaultable(self) -> None:
+        set_config("Machine", "version", str(FIVE))
         a_multicast = RoutingEntry(
             processor_ids=[], link_ids=[1], incoming_link=4)
         b_multicast = RoutingEntry(


### PR DESCRIPTION
MAX_CORES_PER_ROUTER is the same as max cores

As the value changes in spin2 the cleanest is to use 
View.get_machine_version().max_cores_per_chip

