### PR TITLE
split out external links

### DIFF
--- a/spinn_machine/data/machine_data_view.py
+++ b/spinn_machine/data/machine_data_view.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from spinn_machine.chip import Chip
     from spinn_machine.fpga_links import FpgaLinks
     from spinn_machine.machine import Machine
+    from spinn_machine.spinnaker_links import SpinnakerLinks
     from spinn_machine.version.abstract_version import AbstractVersion
 # pylint: disable=protected-access
 
@@ -56,6 +57,7 @@ class _MachineDataModel(object):
         "_n_chips_required",
         "_n_chips_in_graph",
         "_quad_map",
+        "_spinnaker_links",
         "_user_accessed_machine",
         "_v_to_p_map"
     ]
@@ -90,6 +92,7 @@ class _MachineDataModel(object):
         self._fpga_links: Optional[FpgaLinks] = None
         self._machine: Optional[Machine] = None
         self._n_chips_in_graph: Optional[int] = None
+        self._spinnaker_links: Optional[SpinnakerLinks] = None
         self._v_to_p_map: Optional[Dict[XY, bytes]] = None
         self._user_accessed_machine = False
 
@@ -510,3 +513,17 @@ class MachineDataView(UtilsDataView):
         from spinn_machine.fpga_links import FpgaLinks
         cls.__data._fpga_links = FpgaLinks()
         return cls.__data._fpga_links
+
+    @classmethod
+    def get_spinnaker_links(cls) -> SpinnakerLinks:
+        """
+        :return: The Spinnaker links on the related machine
+        """
+        if cls.__data._spinnaker_links:
+            return cls.__data._spinnaker_links
+
+        # delayed import due to circular dependencies
+        # pylint: disable=import-outside-toplevel
+        from spinn_machine.spinnaker_links import SpinnakerLinks
+        cls.__data._spinnaker_links = SpinnakerLinks()
+        return cls.__data._spinnaker_links

--- a/spinn_machine/data/machine_data_view.py
+++ b/spinn_machine/data/machine_data_view.py
@@ -20,7 +20,7 @@ from spinn_machine.exceptions import SpinnMachineException
 from spinn_machine.version.version_factory import version_factory
 if TYPE_CHECKING:
     from spinn_machine.chip import Chip
-    from spinn_machine.fpga_links import FpgaLinks
+    from spinn_machine.fpga_links import FPGALinks
     from spinn_machine.machine import Machine
     from spinn_machine.spinnaker_links import SpinnakerLinks
     from spinn_machine.version.abstract_version import AbstractVersion
@@ -89,7 +89,7 @@ class _MachineDataModel(object):
         self._soft_reset()
         self._all_monitor_cores: int = 0
         self._ethernet_monitor_cores: int = 0
-        self._fpga_links: Optional[FpgaLinks] = None
+        self._fpga_links: Optional[FPGALinks] = None
         self._machine: Optional[Machine] = None
         self._n_chips_in_graph: Optional[int] = None
         self._spinnaker_links: Optional[SpinnakerLinks] = None
@@ -501,7 +501,7 @@ class MachineDataView(UtilsDataView):
         return "No requirements known"
 
     @classmethod
-    def get_fpga_links(cls) -> FpgaLinks:
+    def get_fpga_links(cls) -> FPGALinks:
         """
         :return: The FPGA links on the related machine
         """
@@ -510,8 +510,8 @@ class MachineDataView(UtilsDataView):
 
         # delayed import due to circular dependencies
         # pylint: disable=import-outside-toplevel
-        from spinn_machine.fpga_links import FpgaLinks
-        cls.__data._fpga_links = FpgaLinks()
+        from spinn_machine.fpga_links import FPGALinks
+        cls.__data._fpga_links = FPGALinks()
         return cls.__data._fpga_links
 
     @classmethod

--- a/spinn_machine/data/machine_data_view.py
+++ b/spinn_machine/data/machine_data_view.py
@@ -20,6 +20,7 @@ from spinn_machine.exceptions import SpinnMachineException
 from spinn_machine.version.version_factory import version_factory
 if TYPE_CHECKING:
     from spinn_machine.chip import Chip
+    from spinn_machine.fpga_links import FpgaLinks
     from spinn_machine.machine import Machine
     from spinn_machine.version.abstract_version import AbstractVersion
 # pylint: disable=protected-access
@@ -48,6 +49,7 @@ class _MachineDataModel(object):
         # Data values cached
         "_all_monitor_cores",
         "_ethernet_monitor_cores",
+        "_fpga_links",
         "_machine",
         "_machine_version",
         "_n_boards_required",
@@ -85,6 +87,7 @@ class _MachineDataModel(object):
         self._soft_reset()
         self._all_monitor_cores: int = 0
         self._ethernet_monitor_cores: int = 0
+        self._fpga_links: Optional[FpgaLinks] = None
         self._machine: Optional[Machine] = None
         self._n_chips_in_graph: Optional[int] = None
         self._v_to_p_map: Optional[Dict[XY, bytes]] = None
@@ -493,3 +496,17 @@ class MachineDataView(UtilsDataView):
             return (f"Graph requires "
                     f"{cls.__data._n_chips_in_graph} Chips")
         return "No requirements known"
+
+    @classmethod
+    def get_fpga_links(cls) -> FpgaLinks:
+        """
+        :return: The FPGA links on the related machine
+        """
+        if cls.__data._fpga_links:
+            return cls.__data._fpga_links
+
+        # delayed import due to circular dependencies
+        # pylint: disable=import-outside-toplevel
+        from spinn_machine.fpga_links import FpgaLinks
+        cls.__data._fpga_links = FpgaLinks()
+        return cls.__data._fpga_links

--- a/spinn_machine/fpga_links.py
+++ b/spinn_machine/fpga_links.py
@@ -28,7 +28,7 @@ from spinn_machine.version.version_5 import Version5
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
-_FpgaLinkKey: TypeAlias = tuple[[str | XY], int, int]
+_FpgaLinkKey: TypeAlias = tuple[str | XY, int, int]
 
 
 class FpgaLinks(object):
@@ -64,7 +64,7 @@ class FpgaLinks(object):
             raise SpinnMachineException(
                 f"{version=} does not support FPGA links")
 
-    def __init__(self):
+    def __init__(self) -> None:
         version = self.get_fpga_version()
         self._fpga_links: dict[_FpgaLinkKey, FPGALinkData] = dict()
 

--- a/spinn_machine/fpga_links.py
+++ b/spinn_machine/fpga_links.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FPGA Links on a SpiNNaker machine
+"""
+import logging
+from typing import Optional, TypeAlias
+
+from spinn_utilities.log import FormatAdapter
+from spinn_utilities.typing.coords import XY
+
+from spinn_machine.data import MachineDataView
+from spinn_machine.exceptions import SpinnMachineException
+from spinn_machine.link_data_objects import FPGALinkData
+from spinn_machine.version.version_5 import Version5
+
+logger = FormatAdapter(logging.getLogger(__name__))
+
+_FpgaLinkKey: TypeAlias = tuple[[str | XY], int, int]
+
+
+class FpgaLinks(object):
+    """
+    Represents the Fpga links associated with the Machine
+
+    The use case is
+    fpga_links = View.get_fpga_links()
+    fpga_links.get_fpga_link_with_id
+    This requires a Machine to exist or be creatable
+
+
+    A fail fast test to see if Fpga links are supported is
+    FpgaLinks.get_fpga_version()
+    This call works as soon as cfg data read in. No Machine needed.
+    """
+
+    __slots__ = (
+        "_fpga_links")
+
+    @staticmethod
+    def get_fpga_version() -> Version5:
+        """
+        Checks the version supports FPGA links
+
+        :return: A Version that supports FPGA links
+        :raises SpinnMachineException: If FPGA links not supported
+         """
+        version = MachineDataView.get_machine_version()
+        if isinstance(version, Version5):
+            return version
+        else:
+            raise SpinnMachineException(
+                f"{version=} does not support FPGA links")
+
+    def __init__(self):
+        version = self.get_fpga_version()
+        self._fpga_links: dict[_FpgaLinkKey, FPGALinkData] = dict()
+
+        machine = MachineDataView.get_machine()
+        for ethernet in machine._ethernet_connected_chips:
+            ip = ethernet.ip_address
+            assert ip is not None
+            for (local_x, local_y, link, fpga_id, fpga_link) in \
+                    version.fpga_links():
+                global_x, global_y = machine.get_global_xy(
+                    local_x, local_y, ethernet.x, ethernet.y)
+                chip = machine.get_chip_at(global_x, global_y)
+                if chip is not None:
+                    self._add_fpga_link(fpga_id, fpga_link, chip.x, chip.y,
+                                        link, ip, ethernet.x, ethernet.y)
+
+    def _add_fpga_link(
+            self, fpga_id: int, fpga_link: int, x: int, y: int, link: int,
+            board_address: str, ex: int, ey: int) -> None:
+        link_data = FPGALinkData(
+            fpga_link_id=fpga_link, fpga_id=fpga_id,
+            connected_chip_x=x, connected_chip_y=y,
+            connected_link=link, board_address=board_address)
+        self._fpga_links[board_address, fpga_id, fpga_link] = link_data
+        # Add for the exact chip coordinates
+        self._fpga_links[(x, y), fpga_id, fpga_link] = link_data
+        # Add for the Ethernet chip coordinates to allow this to work too
+        self._fpga_links[(ex, ey), fpga_id, fpga_link] = link_data
+
+    @staticmethod
+    def _next_fpga_link(fpga_id: int, fpga_link: int) -> tuple[int, int]:
+        if fpga_link == 15:
+            return fpga_id + 1, 0
+        return fpga_id, fpga_link + 1
+
+
+    def get_fpga_link_with_id(
+            self, fpga_id: int, fpga_link_id: int,
+            board_address: Optional[str] = None,
+            chip_coords: Optional[XY] = None) -> FPGALinkData:
+        """
+        Get an FPGA link data item that corresponds to the FPGA and FPGA
+        link for a given board address.
+
+        :param fpga_id:
+            the ID of the FPGA that the data is going through.  Refer to
+            technical document located here for more detail:
+            https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
+        :param fpga_link_id:
+            the link ID of the FPGA. Refer to technical document located here
+            for more detail:
+            https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
+        :param board_address:
+            optional board address that this FPGA link is associated with.
+            This is ignored if chip_coords is not `None`.
+            If this is `None` and chip_coords is `None`, the boot board will be
+            assumed.
+        :param chip_coords:
+            optional chip coordinates that this FPGA link is associated with.
+            If this is `None` and board_address is `None`, the boot board
+            will be assumed.
+        :return: the given FPGA link object
+        """
+        # Try chip coordinates first
+        if chip_coords is not None:
+            if board_address is not None:
+                logger.warning(
+                    "Board address will be ignored because chip coordinates"
+                    " are specified")
+            c_key = (chip_coords, fpga_id, fpga_link_id)
+            link_data = self._fpga_links.get(c_key, None)
+            if link_data is not None:
+                return link_data
+            machine = MachineDataView.get_machine()
+            x, y = chip_coords
+            if not machine.is_chip_at(x, y):
+                raise KeyError(f"No chip {x=} {y=} found!")
+            raise KeyError(
+                f"FPGA {fpga_id}, link {fpga_link_id} not found"
+                f" on chip {chip_coords}")
+
+        # Otherwise try board address
+        machine = MachineDataView.get_machine()
+        if board_address is None:
+            board_address = machine.boot_chip.ip_address
+            assert board_address is not None
+        b_key = (board_address, fpga_id, fpga_link_id)
+        if b_key not in self._fpga_links:
+            raise KeyError(
+                f"FPGA Link {fpga_id}:{fpga_link_id} does not exist on board"
+                f" {board_address}")
+        return self._fpga_links[b_key]
+
+    @property
+    def n_fpga_links(self) -> int:
+        """
+        The number of FPGA links in the machine.
+        """
+        return len(self._fpga_links)
+
+
+    def __str__(self) -> str:
+        return f"{self.n_fpga_links} FPGA Links"
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/spinn_machine/fpga_links.py
+++ b/spinn_machine/fpga_links.py
@@ -46,8 +46,7 @@ class FPGALinks(object):
     This call works as soon as cfg data read in. No Machine needed.
     """
 
-    __slots__ = (
-        "_fpga_links")
+    __slots__ = ("_fpga_links",)
 
     @staticmethod
     def get_fpga_version() -> Version5:

--- a/spinn_machine/fpga_links.py
+++ b/spinn_machine/fpga_links.py
@@ -31,9 +31,9 @@ logger = FormatAdapter(logging.getLogger(__name__))
 _FpgaLinkKey: TypeAlias = tuple[str | XY, int, int]
 
 
-class FpgaLinks(object):
+class FPGALinks(object):
     """
-    Represents the Fpga links associated with the Machine
+    Represents the FPGA links associated with the Machine
 
     The use case is
     fpga_links = View.get_fpga_links()
@@ -41,8 +41,8 @@ class FpgaLinks(object):
     This requires a Machine to exist or be creatable
 
 
-    A fail fast test to see if Fpga links are supported is
-    FpgaLinks.get_fpga_version()
+    A fail fast test to see if FPGA links are supported is
+    FPGALinks.get_fpga_version()
     This call works as soon as cfg data read in. No Machine needed.
     """
 

--- a/spinn_machine/fpga_links.py
+++ b/spinn_machine/fpga_links.py
@@ -100,7 +100,6 @@ class FpgaLinks(object):
             return fpga_id + 1, 0
         return fpga_id, fpga_link + 1
 
-
     def get_fpga_link_with_id(
             self, fpga_id: int, fpga_link_id: int,
             board_address: Optional[str] = None,
@@ -164,7 +163,6 @@ class FpgaLinks(object):
         The number of FPGA links in the machine.
         """
         return len(self._fpga_links)
-
 
     def __str__(self) -> str:
         return f"{self.n_fpga_links} FPGA Links"

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -158,7 +158,6 @@ def machine_from_json(j_machine: Union[JsonObject, str]) -> Machine:
         machine.add_chip(chip)
 
     machine.add_spinnaker_links()
-    machine.add_fpga_links()
 
     return machine
 

--- a/spinn_machine/json_machine.py
+++ b/spinn_machine/json_machine.py
@@ -157,8 +157,6 @@ def machine_from_json(j_machine: Union[JsonObject, str]) -> Machine:
                 _int(tag) for tag in tag_ids])
         machine.add_chip(chip)
 
-    machine.add_spinnaker_links()
-
     return machine
 
 

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -15,16 +15,14 @@ from __future__ import annotations
 from collections import Counter
 import logging
 from typing import (
-    Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple, Union,
+    Dict, Iterable, Iterator, List, Optional, Never, Sequence, Set, Tuple,
     TYPE_CHECKING)
-from typing_extensions import TypeAlias
 
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY
 
 from spinn_machine.data import MachineDataView
-from spinn_machine.link_data_objects import FPGALinkData, SpinnakerLinkData
 from .exceptions import (
     SpinnMachineAlreadyExistsException, SpinnMachineException)
 
@@ -32,9 +30,6 @@ if TYPE_CHECKING:
     from .chip import Chip
 
 logger = FormatAdapter(logging.getLogger(__name__))
-
-_SpinLinkKey: TypeAlias = Tuple[Union[str, XY], int]
-_FpgaLinkKey: TypeAlias = Tuple[Union[str, XY], int, int]
 
 
 class Machine(object, metaclass=AbstractBase):
@@ -72,7 +67,6 @@ class Machine(object, metaclass=AbstractBase):
         # Extra information about how this machine was created
         # to be used in the str method
         "_origin",
-        "_spinnaker_links",
         # A Counter for SDRAM on each Chip
         "_sdram_counter",
         # Declared width of the machine
@@ -102,10 +96,6 @@ class Machine(object, metaclass=AbstractBase):
 
         # The list of chips with Ethernet connections
         self._ethernet_connected_chips: List[Chip] = list()
-
-        # The dictionary of SpiNNaker links by board address and "ID" (int)
-        self._spinnaker_links: Dict[_SpinLinkKey, SpinnakerLinkData] = dict()
-
         # Store the boot chip information
         self._boot_ethernet_address: Optional[str] = None
 
@@ -690,63 +680,24 @@ class Machine(object, metaclass=AbstractBase):
         """
         return len(self._ethernet_connected_chips)
 
-    @property
-    def spinnaker_links(self) -> Iterator[
-            Tuple[_SpinLinkKey, SpinnakerLinkData]]:
-        """
-        The set of SpiNNaker links in the machine.
-        """
-        return iter(self._spinnaker_links.items())
-
     def get_spinnaker_link_with_id(
             self, spinnaker_link_id: int, board_address: Optional[str] = None,
-            chip_coords: Optional[XY] = None) -> SpinnakerLinkData:
+            chip_coords: Optional[XY] = None) -> Never:
         """
-        Get a SpiNNaker link with a given ID.
+        Moved to SpinnakerLinks Object
 
-        :param spinnaker_link_id: The ID of the link
-        :param board_address:
-            optional board address that this SpiNNaker link is associated with.
-            This is ignored if chip_coords is not `None`.
-            If this is `None` and chip_coords is `None`,
-            the boot board will be assumed.
-        :param chip_coords:
-            optional chip coordinates that this SpiNNaker link is associated
-            with. If this is `None` and board_address is `None`, the boot board
-            will be assumed.
-        :return: The SpiNNaker link data
+        Use View.get_spinnaker_links().get_spinnaker_link_with_id instead
+
+        :raises NotImplementedError
         """
-        # Try chip coordinates first
-        if chip_coords is not None:
-            if board_address is not None:
-                logger.warning(
-                    "Board address will be ignored because chip coordinates"
-                    " are specified")
-            if chip_coords not in self._chips:
-                raise KeyError(f"No chip {chip_coords} found!")
-            c_key = (chip_coords, spinnaker_link_id)
-            link_data = self._spinnaker_links.get(c_key, None)
-            if link_data is not None:
-                return link_data
-            raise KeyError(
-                f"SpiNNaker link {spinnaker_link_id} not found"
-                f" on chip {chip_coords}")
+        raise NotImplementedError(
+            "Moved to View.get_fpga_links().get_fpga_link_with_id")
 
-        # Otherwise try board address.
-        if board_address is None:
-            board_address = self._boot_ethernet_address
-            assert board_address is not None
-        a_key = (board_address, spinnaker_link_id)
-        if a_key not in self._spinnaker_links:
-            raise KeyError(
-                f"SpiNNaker Link {spinnaker_link_id} does not exist on board"
-                f" {board_address}")
-        return self._spinnaker_links[a_key]
 
     def get_fpga_link_with_id(
             self, fpga_id: int, fpga_link_id: int,
             board_address: Optional[str] = None,
-            chip_coords: Optional[XY] = None) -> FPGALinkData:
+            chip_coords: Optional[XY] = None) -> Never:
         """
         Moved to FpgaLinks Object
 
@@ -756,44 +707,6 @@ class Machine(object, metaclass=AbstractBase):
         """
         raise NotImplementedError(
             "Moved to View.get_fpga_links().get_fpga_link_with_id")
-
-    @property
-    def n_fpga_links(self) -> int:
-        """
-        Moved to FpgaLinks Object
-
-        Use View.get_fpga_links().n_fpga_links instead
-
-        :raises NotImplementedError
-        """
-        raise NotImplementedError(
-            "Moved to View.get_fpga_links().n_fpga_links")
-
-    def add_spinnaker_links(self) -> None:
-        """
-        Add SpiNNaker links that are on a given machine depending on the
-        version of the board.
-        """
-        version = MachineDataView.get_machine_version()
-        for ethernet in self._ethernet_connected_chips:
-            ip = ethernet.ip_address
-            assert ip is not None
-            for (s_id, (local_x, local_y, link)) in enumerate(
-                    version.spinnaker_links()):
-                global_x, global_y = self.get_global_xy(
-                    local_x, local_y, ethernet.x, ethernet.y)
-                chip = self.get_chip_at(global_x, global_y)
-                if chip is not None and not chip.router.is_link(link):
-                    self._add_spinnaker_link(
-                        s_id, global_x, global_y, link, ip)
-
-    def _add_spinnaker_link(
-            self, spinnaker_link_id: int, x: int, y: int, link: int,
-            board_address: str) -> None:
-        link_data = SpinnakerLinkData(
-            spinnaker_link_id, x, y, link, board_address)
-        self._spinnaker_links[board_address, spinnaker_link_id] = link_data
-        self._spinnaker_links[(x, y), spinnaker_link_id] = link_data
 
     def __str__(self) -> str:
         if len(self._ethernet_connected_chips) > 1:

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -59,7 +59,6 @@ class Machine(object, metaclass=AbstractBase):
         "_chip_core_map",
         "_chips",
         "_ethernet_connected_chips",
-        "_fpga_links",
         # Declared height of the machine
         # This can not be changed
         "_height",
@@ -106,9 +105,6 @@ class Machine(object, metaclass=AbstractBase):
 
         # The dictionary of SpiNNaker links by board address and "ID" (int)
         self._spinnaker_links: Dict[_SpinLinkKey, SpinnakerLinkData] = dict()
-
-        # The dictionary of FPGA links by board address, FPGA and link ID
-        self._fpga_links: Dict[_FpgaLinkKey, FPGALinkData] = dict()
 
         # Store the boot chip information
         self._boot_ethernet_address: Optional[str] = None
@@ -752,61 +748,26 @@ class Machine(object, metaclass=AbstractBase):
             board_address: Optional[str] = None,
             chip_coords: Optional[XY] = None) -> FPGALinkData:
         """
-        Get an FPGA link data item that corresponds to the FPGA and FPGA
-        link for a given board address.
+        Moved to FpgaLinks Object
 
-        :param fpga_id:
-            the ID of the FPGA that the data is going through.  Refer to
-            technical document located here for more detail:
-            https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
-        :param fpga_link_id:
-            the link ID of the FPGA. Refer to technical document located here
-            for more detail:
-            https://drive.google.com/file/d/0B9312BuJXntlVWowQlJ3RE8wWVE
-        :param board_address:
-            optional board address that this FPGA link is associated with.
-            This is ignored if chip_coords is not `None`.
-            If this is `None` and chip_coords is `None`, the boot board will be
-            assumed.
-        :param chip_coords:
-            optional chip coordinates that this FPGA link is associated with.
-            If this is `None` and board_address is `None`, the boot board
-            will be assumed.
-        :return: the given FPGA link object
+        Use View.get_fpga_links().get_fpga_link_with_id instead
+
+        :raises NotImplementedError
         """
-        # Try chip coordinates first
-        if chip_coords is not None:
-            if board_address is not None:
-                logger.warning(
-                    "Board address will be ignored because chip coordinates"
-                    " are specified")
-            if chip_coords not in self._chips:
-                raise KeyError(f"No chip {chip_coords} found!")
-            c_key = (chip_coords, fpga_id, fpga_link_id)
-            link_data = self._fpga_links.get(c_key, None)
-            if link_data is not None:
-                return link_data
-            raise KeyError(
-                f"FPGA {fpga_id}, link {fpga_link_id} not found"
-                f" on chip {chip_coords}")
-
-        # Otherwise try board address
-        if board_address is None:
-            board_address = self._boot_ethernet_address
-            assert board_address is not None
-        b_key = (board_address, fpga_id, fpga_link_id)
-        if b_key not in self._fpga_links:
-            raise KeyError(
-                f"FPGA Link {fpga_id}:{fpga_link_id} does not exist on board"
-                f" {board_address}")
-        return self._fpga_links[b_key]
+        raise NotImplementedError(
+            "Moved to View.get_fpga_links().get_fpga_link_with_id")
 
     @property
     def n_fpga_links(self) -> int:
         """
-        The number of FPGA links in the machine.
+        Moved to FpgaLinks Object
+
+        Use View.get_fpga_links().n_fpga_links instead
+
+        :raises NotImplementedError
         """
-        return len(self._fpga_links)
+        raise NotImplementedError(
+            "Moved to View.get_fpga_links().n_fpga_links")
 
     def add_spinnaker_links(self) -> None:
         """
@@ -833,43 +794,6 @@ class Machine(object, metaclass=AbstractBase):
             spinnaker_link_id, x, y, link, board_address)
         self._spinnaker_links[board_address, spinnaker_link_id] = link_data
         self._spinnaker_links[(x, y), spinnaker_link_id] = link_data
-
-    def add_fpga_links(self) -> None:
-        """
-        Add FPGA links that are on a given machine depending on the
-        version of the board.
-        """
-        version = MachineDataView.get_machine_version()
-        for ethernet in self._ethernet_connected_chips:
-            ip = ethernet.ip_address
-            assert ip is not None
-            for (local_x, local_y, link, fpga_id, fpga_link) in \
-                    version.fpga_links():
-                global_x, global_y = self.get_global_xy(
-                    local_x, local_y, ethernet.x, ethernet.y)
-                chip = self.get_chip_at(global_x, global_y)
-                if chip is not None:
-                    self._add_fpga_link(fpga_id, fpga_link, chip.x, chip.y,
-                                        link, ip, ethernet.x, ethernet.y)
-
-    def _add_fpga_link(
-            self, fpga_id: int, fpga_link: int, x: int, y: int, link: int,
-            board_address: str, ex: int, ey: int) -> None:
-        link_data = FPGALinkData(
-            fpga_link_id=fpga_link, fpga_id=fpga_id,
-            connected_chip_x=x, connected_chip_y=y,
-            connected_link=link, board_address=board_address)
-        self._fpga_links[board_address, fpga_id, fpga_link] = link_data
-        # Add for the exact chip coordinates
-        self._fpga_links[(x, y), fpga_id, fpga_link] = link_data
-        # Add for the Ethernet chip coordinates to allow this to work too
-        self._fpga_links[(ex, ey), fpga_id, fpga_link] = link_data
-
-    @staticmethod
-    def _next_fpga_link(fpga_id: int, fpga_link: int) -> Tuple[int, int]:
-        if fpga_link == 15:
-            return fpga_id + 1, 0
-        return fpga_id, fpga_link + 1
 
     def __str__(self) -> str:
         if len(self._ethernet_connected_chips) > 1:

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -700,7 +700,7 @@ class Machine(object, metaclass=AbstractBase):
             board_address: Optional[str] = None,
             chip_coords: Optional[XY] = None) -> Never:
         """
-        Moved to FpgaLinks Object
+        Moved to FPGALinks Object
 
         Use View.get_fpga_links().get_fpga_link_with_id instead
 

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -690,9 +690,9 @@ class Machine(object, metaclass=AbstractBase):
 
         Use View.get_spinnaker_links().get_spinnaker_link_with_id instead
 
-        :raises NotImplementedError
+        :raises SpinnMachineException
         """
-        raise NotImplementedError(
+        raise SpinnMachineException(
             "Moved to View.get_fpga_links().get_fpga_link_with_id")
 
     def get_fpga_link_with_id(
@@ -704,9 +704,9 @@ class Machine(object, metaclass=AbstractBase):
 
         Use View.get_fpga_links().get_fpga_link_with_id instead
 
-        :raises NotImplementedError
+        :raises SpinnMachineException
         """
-        raise NotImplementedError(
+        raise SpinnMachineException(
             "Moved to View.get_fpga_links().get_fpga_link_with_id")
 
     def __str__(self) -> str:

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -695,7 +695,6 @@ class Machine(object, metaclass=AbstractBase):
         raise NotImplementedError(
             "Moved to View.get_fpga_links().get_fpga_link_with_id")
 
-
     def get_fpga_link_with_id(
             self, fpga_id: int, fpga_link_id: int,
             board_address: Optional[str] = None,

--- a/spinn_machine/machine.py
+++ b/spinn_machine/machine.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 from collections import Counter
 import logging
 from typing import (
-    Dict, Iterable, Iterator, List, Optional, Never, Sequence, Set, Tuple,
+    Dict, Iterable, Iterator, List, Optional, Sequence, Set, Tuple,
     TYPE_CHECKING)
+
+from typing_extensions import Never
 
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_utilities.log import FormatAdapter

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -70,7 +70,6 @@ def _machine_ignore(
                 chip.ip_address, chip.tag_ids)
         new_machine.add_chip(chip)
     new_machine.add_spinnaker_links()
-    new_machine.add_fpga_links()
     new_machine.validate()
     return new_machine
 

--- a/spinn_machine/machine_factory.py
+++ b/spinn_machine/machine_factory.py
@@ -69,7 +69,6 @@ def _machine_ignore(
                 chip.nearest_ethernet_x, chip.nearest_ethernet_y,
                 chip.ip_address, chip.tag_ids)
         new_machine.add_chip(chip)
-    new_machine.add_spinnaker_links()
     new_machine.validate()
     return new_machine
 

--- a/spinn_machine/spinnaker_links.py
+++ b/spinn_machine/spinnaker_links.py
@@ -16,7 +16,7 @@
 FPGA Links on a SpiNNaker machine
 """
 import logging
-from typing import Iterator, Optional, TypeAlias
+from typing import Iterator, Optional, TypeAlias, Union
 
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY
@@ -28,7 +28,7 @@ from spinn_machine.version.version_spin1 import VersionSpin1
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
-_SpinLinkKey: TypeAlias = tuple[[str | XY], int]
+_SpinLinkKey: TypeAlias = tuple[str | XY, int]
 
 
 class SpinnakerLinks(object):
@@ -64,7 +64,7 @@ class SpinnakerLinks(object):
             raise SpinnMachineException(
                 f"{version=} does not support Spinnaker links")
 
-    def __init__(self):
+    def __init__(self) -> None:
         version = self.get_spinnaker_version()
         # The dictionary of SpiNNaker links by board address and "ID" (int)
         self._spinnaker_links: dict[_SpinLinkKey, SpinnakerLinkData] = dict()
@@ -146,7 +146,7 @@ class SpinnakerLinks(object):
         self._spinnaker_links[(x, y), spinnaker_link_id] = link_data
 
     def __str__(self) -> str:
-        return f"{len(self.self._spinnaker_links)} Spinnaker Links"
+        return f"{len(self._spinnaker_links)} Spinnaker Links"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/spinn_machine/spinnaker_links.py
+++ b/spinn_machine/spinnaker_links.py
@@ -46,8 +46,7 @@ class SpinnakerLinks(object):
     This call works as soon as cfg data read in. No Machine needed.
     """
 
-    __slots__ = (
-        "_spinnaker_links")
+    __slots__ = ("_spinnaker_links",)
 
     @staticmethod
     def get_spinnaker_version() -> VersionSpin1:

--- a/spinn_machine/spinnaker_links.py
+++ b/spinn_machine/spinnaker_links.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+FPGA Links on a SpiNNaker machine
+"""
+import logging
+from typing import Iterator, Optional, TypeAlias
+
+from spinn_utilities.log import FormatAdapter
+from spinn_utilities.typing.coords import XY
+
+from spinn_machine.data import MachineDataView
+from spinn_machine.exceptions import SpinnMachineException
+from spinn_machine.link_data_objects import SpinnakerLinkData
+from spinn_machine.version.version_spin1 import VersionSpin1
+
+logger = FormatAdapter(logging.getLogger(__name__))
+
+_SpinLinkKey: TypeAlias = tuple[[str | XY], int]
+
+
+class SpinnakerLinks(object):
+    """
+    Represents the spinnaker links associated with the Machine
+
+    The use case is
+    spinnaker_links = View.get_fpga_links()
+    spinnaker_links.get_fpga_link_with_id
+    This requires a Machine to exist or be creatable
+
+
+    A fail fast test to see if Fpga links are supported is
+    FpgaLinks.get_fpga_version()
+    This call works as soon as cfg data read in. No Machine needed.
+    """
+
+    __slots__ = (
+        "_spinnaker_links")
+
+    @staticmethod
+    def get_spinnaker_version() -> VersionSpin1:
+        """
+        Checks the version supports spinnaker links
+
+        :return: A Version that supports Spinnaker links
+        :raises SpinnMachineException: If Spinnaker links not supported
+         """
+        version = MachineDataView.get_machine_version()
+        if isinstance(version, VersionSpin1):
+            return version
+        else:
+            raise SpinnMachineException(
+                f"{version=} does not support Spinnaker links")
+
+    def __init__(self):
+        version = self.get_spinnaker_version()
+        # The dictionary of SpiNNaker links by board address and "ID" (int)
+        self._spinnaker_links: dict[_SpinLinkKey, SpinnakerLinkData] = dict()
+
+        machine = MachineDataView.get_machine()
+        for ethernet in machine.ethernet_connected_chips:
+            ip = ethernet.ip_address
+            assert ip is not None
+            for (s_id, (local_x, local_y, link)) in enumerate(
+                    version.spinnaker_links()):
+                global_x, global_y = machine.get_global_xy(
+                    local_x, local_y, ethernet.x, ethernet.y)
+                chip = machine.get_chip_at(global_x, global_y)
+                if chip is not None and not chip.router.is_link(link):
+                    self._add_spinnaker_link(
+                        s_id, global_x, global_y, link, ip)
+
+    @property
+    def spinnaker_links(self) -> Iterator[
+            tuple[_SpinLinkKey, SpinnakerLinkData]]:
+        """
+        The set of SpiNNaker links in the machine.
+        """
+        return iter(self._spinnaker_links.items())
+
+    def get_spinnaker_link_with_id(
+            self, spinnaker_link_id: int, board_address: Optional[str] = None,
+            chip_coords: Optional[XY] = None) -> SpinnakerLinkData:
+        """
+        Get a SpiNNaker link with a given ID.
+
+        :param spinnaker_link_id: The ID of the link
+        :param board_address:
+            optional board address that this SpiNNaker link is associated with.
+            This is ignored if chip_coords is not `None`.
+            If this is `None` and chip_coords is `None`,
+            the boot board will be assumed.
+        :param chip_coords:
+            optional chip coordinates that this SpiNNaker link is associated
+            with. If this is `None` and board_address is `None`, the boot board
+            will be assumed.
+        :return: The SpiNNaker link data
+        """
+        # Try chip coordinates first
+        if chip_coords is not None:
+            if board_address is not None:
+                logger.warning(
+                    "Board address will be ignored because chip coordinates"
+                    " are specified")
+            c_key = (chip_coords, spinnaker_link_id)
+            link_data = self._spinnaker_links.get(c_key, None)
+            if link_data is not None:
+                return link_data
+            machine = MachineDataView.get_machine()
+            if chip_coords not in machine._chips:
+                raise KeyError(f"No chip {chip_coords} found!")
+            raise KeyError(
+                f"SpiNNaker link {spinnaker_link_id} not found"
+                f" on chip {chip_coords}")
+
+        # Otherwise try board address.
+        if board_address is None:
+            machine = MachineDataView.get_machine()
+            board_address = machine.boot_chip.ip_address
+            assert board_address is not None
+        a_key = (board_address, spinnaker_link_id)
+        if a_key not in self._spinnaker_links:
+            raise KeyError(
+                f"SpiNNaker Link {spinnaker_link_id} does not exist on board"
+                f" {board_address}")
+        return self._spinnaker_links[a_key]
+
+    def _add_spinnaker_link(
+            self, spinnaker_link_id: int, x: int, y: int, link: int,
+            board_address: str) -> None:
+        link_data = SpinnakerLinkData(
+            spinnaker_link_id, x, y, link, board_address)
+        self._spinnaker_links[board_address, spinnaker_link_id] = link_data
+        self._spinnaker_links[(x, y), spinnaker_link_id] = link_data
+
+    def __str__(self) -> str:
+        return f"{len(self.self._spinnaker_links)} Spinnaker Links"
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/spinn_machine/spinnaker_links.py
+++ b/spinn_machine/spinnaker_links.py
@@ -16,7 +16,7 @@
 FPGA Links on a SpiNNaker machine
 """
 import logging
-from typing import Iterator, Optional, TypeAlias, Union
+from typing import Iterator, Optional, TypeAlias
 
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.typing.coords import XY

--- a/spinn_machine/spinnaker_links.py
+++ b/spinn_machine/spinnaker_links.py
@@ -118,7 +118,7 @@ class SpinnakerLinks(object):
             if link_data is not None:
                 return link_data
             machine = MachineDataView.get_machine()
-            if chip_coords not in machine._chips:
+            if chip_coords not in machine.chips:
                 raise KeyError(f"No chip {chip_coords} found!")
             raise KeyError(
                 f"SpiNNaker link {spinnaker_link_id} not found"

--- a/spinn_machine/spinnaker_links.py
+++ b/spinn_machine/spinnaker_links.py
@@ -33,7 +33,7 @@ _SpinLinkKey: TypeAlias = tuple[str | XY, int]
 
 class SpinnakerLinks(object):
     """
-    Represents the spinnaker links associated with the Machine
+    Represents the Spinnaker links associated with the Machine
 
     The use case is
     spinnaker_links = View.get_fpga_links()
@@ -41,8 +41,8 @@ class SpinnakerLinks(object):
     This requires a Machine to exist or be creatable
 
 
-    A fail fast test to see if Fpga links are supported is
-    FpgaLinks.get_fpga_version()
+    A fail fast test to see if Spinnaker links are supported is
+    FPGALinks.get_fpga_version()
     This call works as soon as cfg data read in. No Machine needed.
     """
 

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -415,18 +415,6 @@ class AbstractVersion(object, metaclass=AbstractBase):
         raise NotImplementedError
 
     @abstractmethod
-    def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
-        """
-        The list of Local X, Y, link, fpga_link_id and fpga_id
-
-        These are applied local to each Ethernet Chip and even if the link is
-        connected to another board
-
-        :returns: List of Tuples of Local X, Y, link, fpga_link_id and fpga_id
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def quads_maps(self) -> Optional[Dict[int, Tuple[int, int, int]]]:
         """
         If applicable returns a map of virtual id to quad qx, qy, qp

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -403,18 +403,6 @@ class AbstractVersion(object, metaclass=AbstractBase):
         raise NotImplementedError
 
     @abstractmethod
-    def spinnaker_links(self) -> List[Tuple[int, int, int]]:
-        """
-        The list of Local X, Y and link Id to add spinnaker links to
-
-        These are applied local to each Ethernet Chip and only if the link is
-        not connected to another board
-
-        :returns: List of Tuples of Local X, Y, and spinnaker link Id
-        """
-        raise NotImplementedError
-
-    @abstractmethod
     def quads_maps(self) -> Optional[Dict[int, Tuple[int, int, int]]]:
         """
         If applicable returns a map of virtual id to quad qx, qy, qp

--- a/spinn_machine/version/version_201.py
+++ b/spinn_machine/version/version_201.py
@@ -82,9 +82,5 @@ class Version201(VersionSpin2):
     def supports_multiple_boards(self) -> bool:
         return False
 
-    @overrides(VersionSpin2.spinnaker_links)
-    def spinnaker_links(self) -> List[Tuple[int, int, int]]:
-        return []
-
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Version201)

--- a/spinn_machine/version/version_201.py
+++ b/spinn_machine/version/version_201.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Final, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Final, Optional, Sequence, Tuple
 
 from spinn_utilities.typing.coords import XY
 from spinn_utilities.overrides import overrides

--- a/spinn_machine/version/version_201.py
+++ b/spinn_machine/version/version_201.py
@@ -86,9 +86,5 @@ class Version201(VersionSpin2):
     def spinnaker_links(self) -> List[Tuple[int, int, int]]:
         return []
 
-    @overrides(VersionSpin2.fpga_links)
-    def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
-        return []
-
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Version201)

--- a/spinn_machine/version/version_248.py
+++ b/spinn_machine/version/version_248.py
@@ -59,10 +59,5 @@ class Version248(VersionSpin2, Version48Chips):
     def chip_core_map(self) -> Dict[XY, int]:
         return CHIPS_PER_BOARD
 
-    @overrides(VersionSpin2.spinnaker_links)
-    def spinnaker_links(self) -> List[Tuple[int, int, int]]:
-        # TODO
-        return []
-
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Version248)

--- a/spinn_machine/version/version_248.py
+++ b/spinn_machine/version/version_248.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Final, List, Tuple
+from typing import Any, Dict, Final
 
 from spinn_utilities.typing.coords import XY
 from spinn_utilities.overrides import overrides

--- a/spinn_machine/version/version_248.py
+++ b/spinn_machine/version/version_248.py
@@ -64,10 +64,5 @@ class Version248(VersionSpin2, Version48Chips):
         # TODO
         return []
 
-    @overrides(VersionSpin2.fpga_links)
-    def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
-        # TODO
-        return []
-
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Version248)

--- a/spinn_machine/version/version_3.py
+++ b/spinn_machine/version/version_3.py
@@ -87,10 +87,6 @@ class Version3(VersionSpin1):
     def spinnaker_links(self) -> List[Tuple[int, int, int]]:
         return [(0, 0, 3), (1, 0, 0)]
 
-    @overrides(VersionSpin1.fpga_links)
-    def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
-        return []
-
     @overrides(VersionSpin1.get_idle_energy)
     def get_idle_energy(
             self, time_s: float, n_frames: int, n_boards: int,

--- a/spinn_machine/version/version_5.py
+++ b/spinn_machine/version/version_5.py
@@ -82,8 +82,15 @@ class Version5(VersionSpin1, Version48Chips):
     def spinnaker_links(self) -> List[Tuple[int, int, int]]:
         return [(0, 0, 4)]
 
-    @overrides(VersionSpin1.fpga_links)
     def fpga_links(self) -> List[Tuple[int, int, int, int, int]]:
+        """
+        The list of Local X, Y, link, fpga_link_id and fpga_id
+
+        These are applied local to each Ethernet Chip and even if the link is
+        connected to another board
+
+        :returns: List of Tuples of Local X, Y, link, fpga_link_id and fpga_id
+        """
         return [(0, 0, 3, 1, 1), (0, 0, 4, 1, 0), (0, 0, 5, 0, 15),
                 (0, 1, 3, 1, 3), (0, 1, 4, 1, 2),
                 (0, 2, 3, 1, 5), (0, 2, 4, 1, 4),

--- a/spinn_machine/version/version_spin1.py
+++ b/spinn_machine/version/version_spin1.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from typing import List, Iterable, Tuple, Final
-from spinn_utilities.abstract_base import AbstractBase
+from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_utilities.exceptions import ConfigException
 from spinn_utilities.overrides import overrides
 
@@ -124,3 +124,15 @@ class VersionSpin1(AbstractVersion, metaclass=AbstractBase):
     def _get_core_active_energy(
             self, sum_core_active_times: float) -> float:
         return sum_core_active_times * self.WATTS_PER_CORE_ACTIVE_OVERHEAD
+
+    @abstractmethod
+    def spinnaker_links(self) -> List[Tuple[int, int, int]]:
+        """
+        The list of Local X, Y and link Id to add spinnaker links to
+
+        These are applied local to each Ethernet Chip and only if the link is
+        not connected to another board
+
+        :returns: List of Tuples of Local X, Y, and spinnaker link Id
+        """
+        raise NotImplementedError

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -75,9 +75,6 @@ def virtual_machine_generator() -> Machine:
                            "machine settings ignored.")
         machine = machine_from_json(json_path)
 
-    # Work out and add the SpiNNaker links and FPGA links
-    machine.add_spinnaker_links()
-
     logger.info("Created {}", machine.summary_string())
 
     return machine
@@ -279,7 +276,6 @@ class _VirtualMachine(object):
                     xy, scamp_processors, configured_chips)
             self._machine.add_chip(new_chip)
 
-        self._machine.add_spinnaker_links()
         if validate:
             self._machine.validate()
 

--- a/spinn_machine/virtual_machine.py
+++ b/spinn_machine/virtual_machine.py
@@ -77,7 +77,6 @@ def virtual_machine_generator() -> Machine:
 
     # Work out and add the SpiNNaker links and FPGA links
     machine.add_spinnaker_links()
-    machine.add_fpga_links()
 
     logger.info("Created {}", machine.summary_string())
 
@@ -281,7 +280,6 @@ class _VirtualMachine(object):
             self._machine.add_chip(new_chip)
 
         self._machine.add_spinnaker_links()
-        self._machine.add_fpga_links()
         if validate:
             self._machine.validate()
 

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -260,8 +260,6 @@ class SpinnMachineTestCase(unittest.TestCase):
         # TODO use version info from other PR
         with self.assertRaises(KeyError):
             new_machine.get_spinnaker_link_with_id(1)
-        with self.assertRaises(KeyError):
-            new_machine.get_fpga_link_with_id(3, 3)
 
     @parameterized.expand(BIG_BOARD_TYPES)  # Needs multiple boards
     def test_x_y_over_link(self, _: str, ver_num: str) -> None:

--- a/unittests/test_machine.py
+++ b/unittests/test_machine.py
@@ -93,7 +93,8 @@ class SpinnMachineTestCase(unittest.TestCase):
         self.assertEqual(
             "[VirtualNoWrapMachine: width=8, height=8, n_chips=48]",
             new_machine.__repr__())
-        self.assertEqual(2, len(list(new_machine.spinnaker_links)))
+        spinnaker_links = MachineDataView.get_spinnaker_links()
+        self.assertEqual(2, len(list(spinnaker_links.spinnaker_links)))
         self.assertEqual(1023, new_machine.min_n_router_enteries)
 
     def test_summary(self) -> None:
@@ -257,9 +258,6 @@ class SpinnMachineTestCase(unittest.TestCase):
             chips_in_machine = list(
                 new_machine.get_existing_xys_on_board(eth_chip))
             self.assertEqual(len(chips_in_machine), version.n_chips_per_board)
-        # TODO use version info from other PR
-        with self.assertRaises(KeyError):
-            new_machine.get_spinnaker_link_with_id(1)
 
     @parameterized.expand(BIG_BOARD_TYPES)  # Needs multiple boards
     def test_x_y_over_link(self, _: str, ver_num: str) -> None:

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -21,7 +21,7 @@ from spinn_machine.data import MachineDataView
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException)
 from spinn_machine.version import Spin2Gen
-from spinn_machine.fpga_links import FpgaLinks
+from spinn_machine.fpga_links import FPGALinks
 from spinn_machine.spinnaker_links import SpinnakerLinks
 from spinn_machine.virtual_machine import (
     virtual_machine_by_boards, virtual_machine_by_chips,
@@ -79,7 +79,7 @@ class TestVirtualMachine201(unittest.TestCase):
         except SpinnMachineException as ex:
             self.assertIn("does not support Spinnaker links", str(ex))
         try:
-            FpgaLinks.get_fpga_version()
+            FPGALinks.get_fpga_version()
             raise AssertionError("Should not get here")
         except SpinnMachineException as ex:
             self.assertIn("does not support FPGA links", str(ex))

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -20,7 +20,7 @@ from spinn_machine.config_setup import unittest_setup
 from spinn_machine.data import MachineDataView
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException)
-from spinn_machine.version import Spin1Gen, Spin2Gen
+from spinn_machine.version import Spin2Gen
 from spinn_machine.fpga_links import FpgaLinks
 from spinn_machine.spinnaker_links import SpinnakerLinks
 from spinn_machine.virtual_machine import (

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -21,6 +21,7 @@ from spinn_machine.data import MachineDataView
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException)
 from spinn_machine.fpga_links import FpgaLinks
+from spinn_machine.spinnaker_links import SpinnakerLinks
 from spinn_machine.version import SPIN2_1CHIP
 from spinn_machine.virtual_machine import (
     virtual_machine_by_boards, virtual_machine_by_chips,
@@ -72,6 +73,17 @@ class TestVirtualMachine201(unittest.TestCase):
 
     def test_version_SPIN2_1CHIP(self) -> None:
         set_config("Machine", "version", str(SPIN2_1CHIP))
+        try:
+            SpinnakerLinks.get_spinnaker_version()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support Spinnaker links", str(ex))
+        try:
+            FpgaLinks.get_fpga_version()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support FPGA links", str(ex))
+
         vm = virtual_machine(width=1, height=1)
         self.assertEqual(1, vm.n_chips)
         self.assertTrue(vm.is_chip_at(0, 0))
@@ -97,9 +109,13 @@ class TestVirtualMachine201(unittest.TestCase):
             count += 1
         self.assertEqual(1, count)
         self.assertEqual((1, 0), vm.get_unused_xy())
-        self.assertEqual(0, len(list(vm.spinnaker_links)))
         try:
-            FpgaLinks.get_fpga_version()
+            MachineDataView.get_spinnaker_links()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support Spinnaker links", str(ex))
+        try:
+            MachineDataView.get_fpga_links()
             raise AssertionError("Should not get here")
         except SpinnMachineException as ex:
             self.assertIn("does not support FPGA links", str(ex))

--- a/unittests/test_virtual_machine201.py
+++ b/unittests/test_virtual_machine201.py
@@ -20,6 +20,7 @@ from spinn_machine.config_setup import unittest_setup
 from spinn_machine.data import MachineDataView
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException)
+from spinn_machine.fpga_links import FpgaLinks
 from spinn_machine.version import SPIN2_1CHIP
 from spinn_machine.virtual_machine import (
     virtual_machine_by_boards, virtual_machine_by_chips,
@@ -97,7 +98,11 @@ class TestVirtualMachine201(unittest.TestCase):
         self.assertEqual(1, count)
         self.assertEqual((1, 0), vm.get_unused_xy())
         self.assertEqual(0, len(list(vm.spinnaker_links)))
-        self.assertEqual(0, len(vm._fpga_links))
+        try:
+            FpgaLinks.get_fpga_version()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support FPGA links", str(ex))
 
     def test_new_vm_with_max_cores(self) -> None:
         set_config("Machine", "version", str(SPIN2_1CHIP))
@@ -176,12 +181,6 @@ class TestVirtualMachine201(unittest.TestCase):
         # (0, 1), (24,36) is not on this virtual machine
         self.assertEqual(count01, 0)
         self.assertEqual(count04, 0)
-
-    def test_fpga_links_single_board(self) -> None:
-        set_config("Machine", "version", "3")
-        machine = virtual_machine(width=2, height=2)
-        machine.add_fpga_links()
-        self.assertEqual(0, len(machine._fpga_links))
 
     def test_size_2_2(self) -> None:
         set_config("Machine", "version", "2")

--- a/unittests/test_virtual_machine3.py
+++ b/unittests/test_virtual_machine3.py
@@ -18,7 +18,7 @@ from spinn_utilities.config_holder import set_config
 from spinn_machine import Chip, Link, Router, virtual_machine
 from spinn_machine.config_setup import unittest_setup
 from spinn_machine.data import MachineDataView
-from spinn_machine.fpga_links import FpgaLinks
+from spinn_machine.fpga_links import FPGALinks
 from spinn_machine.link_data_objects import SpinnakerLinkData
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException)
@@ -131,7 +131,7 @@ class TestVirtualMachine3(unittest.TestCase):
         expected.append((((1, 0), 1), sp))
         self.assertEqual(expected, spinnaker_links)
         try:
-            FpgaLinks.get_fpga_version()
+            FPGALinks.get_fpga_version()
             raise AssertionError("Should not get here")
         except SpinnMachineException as ex:
             self.assertIn("does not support FPGA links", str(ex))
@@ -228,7 +228,7 @@ class TestVirtualMachine3(unittest.TestCase):
     def test_fpga_links_single_board(self) -> None:
         set_config("Machine", "version", str(Spin1Gen.THREE.value))
         try:
-            FpgaLinks.get_fpga_version()
+            FPGALinks.get_fpga_version()
             raise AssertionError("Should not get here")
         except SpinnMachineException as ex:
             self.assertIn("does not support FPGA links", str(ex))

--- a/unittests/test_virtual_machine3.py
+++ b/unittests/test_virtual_machine3.py
@@ -225,7 +225,6 @@ class TestVirtualMachine3(unittest.TestCase):
         # (24,36) is not on this virtual machine
         self.assertEqual(count04, 0)
 
-
     def test_fpga_links_single_board(self) -> None:
         set_config("Machine", "version", str(Spin1Gen.THREE.value))
         try:
@@ -238,7 +237,6 @@ class TestVirtualMachine3(unittest.TestCase):
             raise AssertionError("Should not get here")
         except SpinnMachineException as ex:
             self.assertIn("does not support FPGA links", str(ex))
-
 
     def test_size_2_2(self) -> None:
         set_config("Machine", "version", "2")

--- a/unittests/test_virtual_machine3.py
+++ b/unittests/test_virtual_machine3.py
@@ -119,7 +119,8 @@ class TestVirtualMachine3(unittest.TestCase):
             count += 1
         self.assertEqual(4, count)
         self.assertEqual((2, 0), vm.get_unused_xy())
-        spinnaker_links = (list(vm.spinnaker_links))
+        links = MachineDataView.get_spinnaker_links()
+        spinnaker_links = (list(links.spinnaker_links))
         expected: List = []
         sp = SpinnakerLinkData(0, 0, 0, 3, '127.0.0.0')
         expected.append((('127.0.0.0', 0), sp))

--- a/unittests/test_virtual_machine3.py
+++ b/unittests/test_virtual_machine3.py
@@ -17,6 +17,8 @@ import unittest
 from spinn_utilities.config_holder import set_config
 from spinn_machine import Chip, Link, Router, virtual_machine
 from spinn_machine.config_setup import unittest_setup
+from spinn_machine.data import MachineDataView
+from spinn_machine.fpga_links import FpgaLinks
 from spinn_machine.link_data_objects import SpinnakerLinkData
 from spinn_machine.exceptions import (
     SpinnMachineException, SpinnMachineAlreadyExistsException)
@@ -126,7 +128,11 @@ class TestVirtualMachine3(unittest.TestCase):
         expected.append((('127.0.0.0', 1), sp))
         expected.append((((1, 0), 1), sp))
         self.assertEqual(expected, spinnaker_links)
-        self.assertEqual(0, len(vm._fpga_links))
+        try:
+            FpgaLinks.get_fpga_version()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support FPGA links", str(ex))
 
     def test_new_vm_with_max_cores(self) -> None:
         set_config("Machine", "version", "2")
@@ -217,11 +223,20 @@ class TestVirtualMachine3(unittest.TestCase):
         # (24,36) is not on this virtual machine
         self.assertEqual(count04, 0)
 
+
     def test_fpga_links_single_board(self) -> None:
         set_config("Machine", "version", "3")
-        machine = virtual_machine(width=2, height=2)
-        machine.add_fpga_links()
-        self.assertEqual(0, len(machine._fpga_links))
+        try:
+            FpgaLinks.get_fpga_version()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support FPGA links", str(ex))
+        try:
+            MachineDataView.get_fpga_links()
+            raise AssertionError("Should not get here")
+        except SpinnMachineException as ex:
+            self.assertIn("does not support FPGA links", str(ex))
+
 
     def test_size_2_2(self) -> None:
         set_config("Machine", "version", "2")

--- a/unittests/test_virtual_machine5.py
+++ b/unittests/test_virtual_machine5.py
@@ -206,8 +206,8 @@ class TestVirtualMachine5(unittest.TestCase):
 
     @staticmethod
     def _assert_fpga_link(
-            fpga_links_object: FpgaLinks, fpga: int, fpga_link: int, x: int, y: int,
-            link_id: int, ip: Optional[str] = None) -> None:
+            fpga_links_object: FpgaLinks, fpga: int, fpga_link: int,
+            x: int, y: int, link_id: int, ip: Optional[str] = None) -> None:
         link = fpga_links_object.get_fpga_link_with_id(fpga, fpga_link, ip)
         assert link.connected_chip_x == x
         assert link.connected_chip_y == y

--- a/unittests/test_virtual_machine5.py
+++ b/unittests/test_virtual_machine5.py
@@ -18,6 +18,9 @@ from spinn_utilities.config_holder import set_config
 
 from spinn_machine import Machine, virtual_machine
 from spinn_machine.config_setup import unittest_setup
+from spinn_machine.data import MachineDataView
+from spinn_machine.data.machine_data_writer import MachineDataWriter
+from spinn_machine.fpga_links import FpgaLinks
 from spinn_machine.link_data_objects import SpinnakerLinkData
 from spinn_machine.version import FIVE
 from spinn_machine.version.version_5 import CHIPS_PER_BOARD
@@ -53,7 +56,7 @@ class TestVirtualMachine5(unittest.TestCase):
 
     def test_version_5_8_by_8(self) -> None:
         set_config("Machine", "version", str(FIVE))
-        vm = virtual_machine(width=8, height=8, validate=True)
+        vm = MachineDataView.get_machine()
         self.assertEqual(48, vm.n_chips)
         self.assertEqual(1, len(vm.ethernet_connected_chips))
         self.assertTrue(vm.is_chip_at(4, 4))
@@ -71,8 +74,10 @@ class TestVirtualMachine5(unittest.TestCase):
         self.assertEqual(expected, spinnaker_links)
         # 8 links on each of the 6 sides recorded 3 times
         # Except for the Ethernet Chip's 3 links which are only recorded twice
+
         expected_fpgas = 8 * 6 * 3 - 3
-        self.assertEqual(expected_fpgas, len(vm._fpga_links))
+        fpga_links = MachineDataView.get_fpga_links()
+        self.assertEqual(expected_fpgas, fpga_links.n_fpga_links)
         keys = set([('127.0.0.0', 0, 0), ((7, 3), 0, 0), ((0, 0), 0, 0),
                     ('127.0.0.0', 0, 1), ((7, 3), 0, 1), ((0, 0), 0, 1),
                     ('127.0.0.0', 0, 2), ((6, 2), 0, 2), ((0, 0), 0, 2),
@@ -121,9 +126,9 @@ class TestVirtualMachine5(unittest.TestCase):
                     ('127.0.0.0', 2, 13), ((7, 4), 2, 13), ((0, 0), 2, 13),
                     ('127.0.0.0', 2, 14), ((7, 4), 2, 14), ((0, 0), 2, 14),
                     ('127.0.0.0', 2, 15), ((7, 3), 2, 15), ((0, 0), 2, 15)])
-        self.assertEqual(keys, set(vm._fpga_links.keys()))
+        self.assertEqual(keys, set(fpga_links._fpga_links.keys()))
         data = set()
-        for (_, fpga_id, fpga_link), link in vm._fpga_links.items():
+        for (_, fpga_id, fpga_link), link in fpga_links._fpga_links.items():
             data.add((link.connected_chip_x, link.connected_chip_y,
                       link.connected_link, fpga_id, fpga_link))
         expectes = set([(7, 3, 0, 0, 0), (7, 3, 5, 0, 1), (6, 2, 0, 0, 2),
@@ -149,6 +154,7 @@ class TestVirtualMachine5(unittest.TestCase):
     def test_version_5_12_by_12(self) -> None:
         set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(height=12, width=12, validate=True)
+        MachineDataWriter.mock().set_machine(vm)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
         count = sum(1 for _chip in vm.chips for _link in _chip.router.links)
@@ -164,11 +170,14 @@ class TestVirtualMachine5(unittest.TestCase):
         # 8 links on each of the 6 sides recorded 3 times
         # Except for the Ethernet Chip's 3 links which are only recorded twice
         expected_fpgas = (8 * 6 * 3 - 3) * 3
-        self.assertEqual(expected_fpgas, len(vm._fpga_links))
+        fpga_links = MachineDataView.get_fpga_links()
+        self.assertEqual(expected_fpgas, len(fpga_links._fpga_links))
 
     def test_version_5_16_by_16(self) -> None:
         set_config("Machine", "version", str(FIVE))
         vm = virtual_machine(height=16, width=16, validate=True)
+        machine = virtual_machine(width=12, height=12)
+        MachineDataWriter.mock().set_machine(vm)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))
         count = sum(1 for _chip in vm.chips for _link in _chip.router.links)
@@ -190,74 +199,74 @@ class TestVirtualMachine5(unittest.TestCase):
         # 8 links on each of the 6 sides recorded 3 times
         # Except for the Ethernet Chip's 3 links which are only recorded twice
         expected_fpgas = (8 * 6 * 3 - 3) * 3
-        self.assertEqual(expected_fpgas, len(vm._fpga_links))
+        fpga_links = MachineDataView.get_fpga_links()
+        self.assertEqual(expected_fpgas, len(fpga_links._fpga_links))
 
     @staticmethod
     def _assert_fpga_link(
-            machine: Machine, fpga: int, fpga_link: int, x: int, y: int,
+            fpga_links_object: FpgaLinks, fpga: int, fpga_link: int, x: int, y: int,
             link_id: int, ip: Optional[str] = None) -> None:
-        link = machine.get_fpga_link_with_id(fpga, fpga_link, ip)
+        link = fpga_links_object.get_fpga_link_with_id(fpga, fpga_link, ip)
         assert link.connected_chip_x == x
         assert link.connected_chip_y == y
         assert link.connected_link == link_id
 
     def test_fpga_links_single_board(self) -> None:
         set_config("Machine", "version", str(FIVE))
-        machine = virtual_machine(width=8, height=8)
-        machine.add_fpga_links()
-        self._assert_fpga_link(machine, 0, 0, 7, 3, 0)
-        self._assert_fpga_link(machine, 0, 1, 7, 3, 5)
-        self._assert_fpga_link(machine, 0, 2, 6, 2, 0)
-        self._assert_fpga_link(machine, 0, 3, 6, 2, 5)
-        self._assert_fpga_link(machine, 0, 4, 5, 1, 0)
-        self._assert_fpga_link(machine, 0, 5, 5, 1, 5)
-        self._assert_fpga_link(machine, 0, 6, 4, 0, 0)
-        self._assert_fpga_link(machine, 0, 7, 4, 0, 5)
+        fpga_links = MachineDataView.get_fpga_links()
+        self._assert_fpga_link(fpga_links, 0, 0, 7, 3, 0)
+        self._assert_fpga_link(fpga_links, 0, 1, 7, 3, 5)
+        self._assert_fpga_link(fpga_links, 0, 2, 6, 2, 0)
+        self._assert_fpga_link(fpga_links, 0, 3, 6, 2, 5)
+        self._assert_fpga_link(fpga_links, 0, 4, 5, 1, 0)
+        self._assert_fpga_link(fpga_links, 0, 5, 5, 1, 5)
+        self._assert_fpga_link(fpga_links, 0, 6, 4, 0, 0)
+        self._assert_fpga_link(fpga_links, 0, 7, 4, 0, 5)
 
-        self._assert_fpga_link(machine, 0, 8, 4, 0, 4)
-        self._assert_fpga_link(machine, 0, 9, 3, 0, 5)
-        self._assert_fpga_link(machine, 0, 10, 3, 0, 4)
-        self._assert_fpga_link(machine, 0, 11, 2, 0, 5)
-        self._assert_fpga_link(machine, 0, 12, 2, 0, 4)
-        self._assert_fpga_link(machine, 0, 13, 1, 0, 5)
-        self._assert_fpga_link(machine, 0, 14, 1, 0, 4)
-        self._assert_fpga_link(machine, 0, 15, 0, 0, 5)
+        self._assert_fpga_link(fpga_links, 0, 8, 4, 0, 4)
+        self._assert_fpga_link(fpga_links, 0, 9, 3, 0, 5)
+        self._assert_fpga_link(fpga_links, 0, 10, 3, 0, 4)
+        self._assert_fpga_link(fpga_links, 0, 11, 2, 0, 5)
+        self._assert_fpga_link(fpga_links, 0, 12, 2, 0, 4)
+        self._assert_fpga_link(fpga_links, 0, 13, 1, 0, 5)
+        self._assert_fpga_link(fpga_links, 0, 14, 1, 0, 4)
+        self._assert_fpga_link(fpga_links, 0, 15, 0, 0, 5)
 
-        self._assert_fpga_link(machine, 1, 0, 0, 0, 4)
-        self._assert_fpga_link(machine, 1, 1, 0, 0, 3)
-        self._assert_fpga_link(machine, 1, 2, 0, 1, 4)
-        self._assert_fpga_link(machine, 1, 3, 0, 1, 3)
-        self._assert_fpga_link(machine, 1, 4, 0, 2, 4)
-        self._assert_fpga_link(machine, 1, 5, 0, 2, 3)
-        self._assert_fpga_link(machine, 1, 6, 0, 3, 4)
-        self._assert_fpga_link(machine, 1, 7, 0, 3, 3)
+        self._assert_fpga_link(fpga_links, 1, 0, 0, 0, 4)
+        self._assert_fpga_link(fpga_links, 1, 1, 0, 0, 3)
+        self._assert_fpga_link(fpga_links, 1, 2, 0, 1, 4)
+        self._assert_fpga_link(fpga_links, 1, 3, 0, 1, 3)
+        self._assert_fpga_link(fpga_links, 1, 4, 0, 2, 4)
+        self._assert_fpga_link(fpga_links, 1, 5, 0, 2, 3)
+        self._assert_fpga_link(fpga_links, 1, 6, 0, 3, 4)
+        self._assert_fpga_link(fpga_links, 1, 7, 0, 3, 3)
 
-        self._assert_fpga_link(machine, 1, 8, 0, 3, 2)
-        self._assert_fpga_link(machine, 1, 9, 1, 4, 3)
-        self._assert_fpga_link(machine, 1, 10, 1, 4, 2)
-        self._assert_fpga_link(machine, 1, 11, 2, 5, 3)
-        self._assert_fpga_link(machine, 1, 12, 2, 5, 2)
-        self._assert_fpga_link(machine, 1, 13, 3, 6, 3)
-        self._assert_fpga_link(machine, 1, 14, 3, 6, 2)
-        self._assert_fpga_link(machine, 1, 15, 4, 7, 3)
+        self._assert_fpga_link(fpga_links, 1, 8, 0, 3, 2)
+        self._assert_fpga_link(fpga_links, 1, 9, 1, 4, 3)
+        self._assert_fpga_link(fpga_links, 1, 10, 1, 4, 2)
+        self._assert_fpga_link(fpga_links, 1, 11, 2, 5, 3)
+        self._assert_fpga_link(fpga_links, 1, 12, 2, 5, 2)
+        self._assert_fpga_link(fpga_links, 1, 13, 3, 6, 3)
+        self._assert_fpga_link(fpga_links, 1, 14, 3, 6, 2)
+        self._assert_fpga_link(fpga_links, 1, 15, 4, 7, 3)
 
-        self._assert_fpga_link(machine, 2, 0, 4, 7, 2)
-        self._assert_fpga_link(machine, 2, 1, 4, 7, 1)
-        self._assert_fpga_link(machine, 2, 2, 5, 7, 2)
-        self._assert_fpga_link(machine, 2, 3, 5, 7, 1)
-        self._assert_fpga_link(machine, 2, 4, 6, 7, 2)
-        self._assert_fpga_link(machine, 2, 5, 6, 7, 1)
-        self._assert_fpga_link(machine, 2, 6, 7, 7, 2)
-        self._assert_fpga_link(machine, 2, 7, 7, 7, 1)
+        self._assert_fpga_link(fpga_links, 2, 0, 4, 7, 2)
+        self._assert_fpga_link(fpga_links, 2, 1, 4, 7, 1)
+        self._assert_fpga_link(fpga_links, 2, 2, 5, 7, 2)
+        self._assert_fpga_link(fpga_links, 2, 3, 5, 7, 1)
+        self._assert_fpga_link(fpga_links, 2, 4, 6, 7, 2)
+        self._assert_fpga_link(fpga_links, 2, 5, 6, 7, 1)
+        self._assert_fpga_link(fpga_links, 2, 6, 7, 7, 2)
+        self._assert_fpga_link(fpga_links, 2, 7, 7, 7, 1)
 
-        self._assert_fpga_link(machine, 2, 8, 7, 7, 0)
-        self._assert_fpga_link(machine, 2, 9, 7, 6, 1)
-        self._assert_fpga_link(machine, 2, 10, 7, 6, 0)
-        self._assert_fpga_link(machine, 2, 11, 7, 5, 1)
-        self._assert_fpga_link(machine, 2, 12, 7, 5, 0)
-        self._assert_fpga_link(machine, 2, 13, 7, 4, 1)
-        self._assert_fpga_link(machine, 2, 14, 7, 4, 0)
-        self._assert_fpga_link(machine, 2, 15, 7, 3, 1)
+        self._assert_fpga_link(fpga_links, 2, 8, 7, 7, 0)
+        self._assert_fpga_link(fpga_links, 2, 9, 7, 6, 1)
+        self._assert_fpga_link(fpga_links, 2, 10, 7, 6, 0)
+        self._assert_fpga_link(fpga_links, 2, 11, 7, 5, 1)
+        self._assert_fpga_link(fpga_links, 2, 12, 7, 5, 0)
+        self._assert_fpga_link(fpga_links, 2, 13, 7, 4, 1)
+        self._assert_fpga_link(fpga_links, 2, 14, 7, 4, 0)
+        self._assert_fpga_link(fpga_links, 2, 15, 7, 3, 1)
 
     def test_fpga_links_3_board(self) -> None:
         set_config("Machine", "version", str(FIVE))
@@ -285,9 +294,11 @@ class TestVirtualMachine5(unittest.TestCase):
                               for _, _, _, x, y, link in fpga_links])
         set_config("Machine", "down_links", down_links)
         machine = virtual_machine(width=12, height=12)
-        machine.add_fpga_links()
+        MachineDataWriter.mock().set_machine(machine)
+        fpga_links_object = MachineDataView.get_fpga_links()
         for ip, fpga, fpga_link, x, y, link in fpga_links:
-            self._assert_fpga_link(machine, fpga, fpga_link, x, y, link, ip)
+            self._assert_fpga_link(
+                fpga_links_object, fpga, fpga_link, x, y, link, ip)
 
     def test_none_triad(self) -> None:
         set_config("Machine", "version", str(FIVE))

--- a/unittests/test_virtual_machine5.py
+++ b/unittests/test_virtual_machine5.py
@@ -66,7 +66,8 @@ class TestVirtualMachine5(unittest.TestCase):
         self.assertEqual(240, count)
         count = sum(_chip.n_processors for _chip in vm.chips)
         self.assertEqual(count, 856)
-        spinnaker_links = (list(vm.spinnaker_links))
+        s_links = MachineDataView.get_spinnaker_links()
+        spinnaker_links = (list(s_links.spinnaker_links))
         expected: List = []
         sp = SpinnakerLinkData(0, 0, 0, 4, '127.0.0.0')
         expected.append((('127.0.0.0', 0), sp))
@@ -164,7 +165,8 @@ class TestVirtualMachine5(unittest.TestCase):
             count += 1
         self.assertEqual(48, count)
         self.assertEqual((12, 0), vm.get_unused_xy())
-        spinnaker_links = (list(vm.spinnaker_links))
+        s_links = MachineDataView.get_spinnaker_links()
+        spinnaker_links = (list(s_links.spinnaker_links))
         expected: List = []
         self.assertEqual(expected, spinnaker_links)
         # 8 links on each of the 6 sides recorded 3 times
@@ -187,7 +189,8 @@ class TestVirtualMachine5(unittest.TestCase):
             count += 1
         self.assertEqual(48, count)
         self.assertEqual((0, 4), vm.get_unused_xy())
-        spinnaker_links = (list(vm.spinnaker_links))
+        s_links = MachineDataView.get_spinnaker_links()
+        spinnaker_links = (list(s_links.spinnaker_links))
         expected: List = []
         sp = SpinnakerLinkData(0, 0, 0, 4, '127.0.0.0')
         expected.append((('127.0.0.0', 0), sp))

--- a/unittests/test_virtual_machine5.py
+++ b/unittests/test_virtual_machine5.py
@@ -20,7 +20,7 @@ from spinn_machine import virtual_machine
 from spinn_machine.config_setup import unittest_setup
 from spinn_machine.data import MachineDataView
 from spinn_machine.data.machine_data_writer import MachineDataWriter
-from spinn_machine.fpga_links import FpgaLinks
+from spinn_machine.fpga_links import FPGALinks
 from spinn_machine.link_data_objects import SpinnakerLinkData
 from spinn_machine.version import Spin1Gen
 from spinn_machine.version.version_5 import CHIPS_PER_BOARD
@@ -206,7 +206,7 @@ class TestVirtualMachine5(unittest.TestCase):
 
     @staticmethod
     def _assert_fpga_link(
-            fpga_links_object: FpgaLinks, fpga: int, fpga_link: int,
+            fpga_links_object: FPGALinks, fpga: int, fpga_link: int,
             x: int, y: int, link_id: int, ip: Optional[str] = None) -> None:
         link = fpga_links_object.get_fpga_link_with_id(fpga, fpga_link, ip)
         assert link.connected_chip_x == x

--- a/unittests/test_virtual_machine5.py
+++ b/unittests/test_virtual_machine5.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 import unittest
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine import Machine, virtual_machine
+from spinn_machine import virtual_machine
 from spinn_machine.config_setup import unittest_setup
 from spinn_machine.data import MachineDataView
 from spinn_machine.data.machine_data_writer import MachineDataWriter
@@ -178,7 +178,6 @@ class TestVirtualMachine5(unittest.TestCase):
     def test_version_5_16_by_16(self) -> None:
         set_config("Machine", "version", str(Spin1Gen.FIVE.value))
         vm = virtual_machine(height=16, width=16, validate=True)
-        machine = virtual_machine(width=12, height=12)
         MachineDataWriter.mock().set_machine(vm)
         self.assertEqual(144, vm.n_chips)
         self.assertEqual(3, len(vm.ethernet_connected_chips))


### PR DESCRIPTION
This only affects the python representation of external links

FPGALinks Done 
spinnaker_links Todo before merge

Advantages.
1. Removes Spin1 only stuff out of the shared Machine Object
2. TODO - Removes Spin1 only stuff from the Spin2 Version objects
3. Avoids calculating link for the 99.99% of runs that do not use them
4. Example of how Spin2 links to the external world could be done

ToBe dettermined.
- Should there be a shared Super Class of links.
   - There was not in Spin1
   - Depends on what Spin2 external links need

Disadvanagtes
- Small code change to users stuff that use these links
- Ugly delayed imports

