### PR TITLE
run code to build cfg template earlier

### DIFF
--- a/spinn_machine/version/version_factory.py
+++ b/spinn_machine/version/version_factory.py
@@ -20,8 +20,8 @@ import os
 from typing_extensions import Never
 
 from spinn_utilities.config_holder import (
-    get_config_bool, get_config_int_or_none, get_config_str_or_none,
-    has_config_option)
+    check_user_cfg, get_config_bool, get_config_int_or_none,
+    get_config_str_or_none, has_config_option)
 from spinn_utilities.log import FormatAdapter
 from spinn_machine.exceptions import SpinnMachineException
 from .spin1_gen import Spin1Gen
@@ -194,6 +194,7 @@ def raise_version_error(error: str, version: Optional[int]) -> Never:
     :param version: version claimed
     :raises SpinnMachineException: Always!
     """
+    check_user_cfg()
     height = get_config_int_or_none("Machine", "height")
     width = get_config_int_or_none("Machine", "width")
 


### PR DESCRIPTION
reminder.
To support unittests that call sim.setup() but do not use any cfg values we delayed when we check if the user has created their cfg and if not write the template.

This is done by storing __missing_config_file during sim.setup.

previously.
the check_user_cfg method which creates the template was called if transceiver creation failed.

but we before we get there we have to get the machine version

SO:
This pr also calls it if version_factory fails.