### PR TITLE
max_cores_per_router

### DIFF
--- a/spinn_machine/router.py
+++ b/spinn_machine/router.py
@@ -149,7 +149,7 @@ class Router(object):
             of all chip links and core links.
         """
         route_entry = 0
-        max_cores = MachineDataView.get_machine_version().max_cores_per_chip
+        max_cores = MachineDataView.get_machine_version().max_cores_per_router
         for processor_id in routing_table_entry.processor_ids:
             if 0 > processor_id >= max_cores:
                 raise SpinnMachineInvalidParameterException(
@@ -177,7 +177,7 @@ class Router(object):
         :param route: The routing table entry
         :return: The list of processor IDs, and the list of link IDs.
         """
-        max_cores = MachineDataView.get_machine_version().max_cores_per_chip
+        max_cores = MachineDataView.get_machine_version().max_cores_per_router
         processor_ids = [pi for pi in range(0, max_cores)
                          if route & 1 << (Router.MAX_LINKS_PER_ROUTER + pi)]
         link_ids = [li for li in range(0, Router.MAX_LINKS_PER_ROUTER)

--- a/spinn_machine/routing_entry.py
+++ b/spinn_machine/routing_entry.py
@@ -216,7 +216,7 @@ class RoutingEntry(object):
         Convert a binary routing table entry usable on the machine to lists of
         route IDs usable in a routing table entry represented in software.
         """
-        max_cores = MachineDataView.get_machine_version().max_cores_per_chip
+        max_cores = MachineDataView.get_machine_version().max_cores_per_router
         processor_ids = (pi for pi in range(0, max_cores)
                          if self._spinnaker_route & 1 <<
                          (Router.MAX_LINKS_PER_ROUTER + pi))

--- a/spinn_machine/version/abstract_version.py
+++ b/spinn_machine/version/abstract_version.py
@@ -50,6 +50,7 @@ class AbstractVersion(object, metaclass=AbstractBase):
     __slots__ = (
         # the board address associated with this tag
         "_max_cores_per_chip",
+        "_max_cores_per_router",
         "_max_sdram_per_chip")
 
     def __init__(self, max_cores_per_chip: int, max_sdram_per_chip: int):
@@ -64,6 +65,7 @@ class AbstractVersion(object, metaclass=AbstractBase):
         self.__verify_config_width_height()
         self.__set_max_cores_per_chip(max_cores_per_chip)
         self.__set_max_sdram_per_chip(max_sdram_per_chip)
+        self._max_cores_per_router = max_cores_per_chip
 
     def __verify_config_width_height(self) -> None:
         """
@@ -155,6 +157,15 @@ class AbstractVersion(object, metaclass=AbstractBase):
         cores, only that there will be no cores with more.
         """
         return self._max_cores_per_chip
+
+    @property
+    def max_cores_per_router(self) -> int:
+        """
+        The theoretical maximum number of off Core links in any router
+
+        There is no guarantee that any route will use this many cores
+        """
+        return self._max_cores_per_router
 
     @property
     @abstractmethod


### PR DESCRIPTION
only needed for cfg max_machine_core

Will likely be replaced with something similar to https://gitlab.com/spinnaker2/SpiNNMachine2/-/merge_requests/9
-That is on hold until the version split of RouterEntry is stable in SpinCloud

One option is to leave this ready to merge and only merge if needed.